### PR TITLE
Implement base REST API server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local configuration
+config.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # autoPoster
-This agent can post to various social media sites.
+
+A simple REST API that receives post requests and forwards them to various services.
+
+## Setup
+
+1. Copy `config.sample.json` to `config.json` and fill in your account details.
+2. Install dependencies:
+   ```bash
+   pip install fastapi uvicorn
+   ```
+3. Run the server:
+   ```bash
+   python server.py
+   ```
+   The API will start on `http://localhost:8765`.
+
+## API
+
+### `POST /post`
+
+Send JSON with the following structure:
+
+```json
+{
+  "text": "Post body",
+  "media": ["base64string1", "base64string2"]
+}
+```
+
+`media` is optional and should contain base64 encoded content of images or videos.
+
+This initial version only acknowledges the request.

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,0 +1,6 @@
+{
+  "note": {
+    "username": "your_username",
+    "password": "your_password"
+  }
+}

--- a/server.py
+++ b/server.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+from typing import List, Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
+
+# Load config if available
+if CONFIG_PATH.exists():
+    with CONFIG_PATH.open() as f:
+        CONFIG = json.load(f)
+else:
+    CONFIG = {}
+
+app = FastAPI(title="autoPoster")
+
+class PostRequest(BaseModel):
+    text: str
+    media: Optional[List[str]] = None  # base64 encoded strings
+
+@app.get("/")
+async def root():
+    return {"status": "ok"}
+
+@app.post("/post")
+async def receive_post(data: PostRequest):
+    # For now just log that data was received
+    media_count = len(data.media or [])
+    return {"received": True, "media_items": media_count}
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=8765)


### PR DESCRIPTION
## Summary
- implement REST API server using FastAPI and uvicorn
- add sample configuration file
- update README with setup instructions and API description
- ignore local config.json file

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_688314a3f86483299951e1ce4d95c26b