### PR TITLE
Add basic API request test script

### DIFF
--- a/test_api_request.py
+++ b/test_api_request.py
@@ -1,0 +1,23 @@
+import json
+import urllib.request
+
+
+def main():
+    url = "http://localhost:8765/post"
+    payload = {"text": "test"}
+    data = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+
+    print(f"Sending POST request to {url} with payload: {payload}")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req) as response:
+            body = response.read().decode("utf-8")
+            print(f"Response status: {response.status}")
+            print(f"Response body: {body}")
+    except Exception as exc:
+        print(f"Request failed: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a test script that posts a simple payload to `localhost:8765`

## Testing
- `python test_api_request.py` (fails without server)

------
https://chatgpt.com/codex/tasks/task_e_68831e55b1a88329b366be5f6903d6f0