### PR TITLE
Add Mastodon config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ A simple REST API that receives post requests and forwards them to various servi
 ## Setup
 
 1. Copy `config.sample.json` to `config.json` and fill in your account details.
+   To add Mastodon accounts, include a `mastodon` section like this:
+
+   ```json
+   "mastodon": {
+       "accounts": {
+           "account1": {
+               "instance_url": "https://mastodon.example",
+               "access_token": "YOUR_TOKEN"
+           }
+       }
+   }
+   ```
 2. Install dependencies:
    ```bash
    pip install -r requirements.txt

--- a/config.sample.json
+++ b/config.sample.json
@@ -2,5 +2,13 @@
   "note": {
     "username": "your_username",
     "password": "your_password"
+  },
+  "mastodon": {
+    "accounts": {
+      "account1": {
+        "instance_url": "https://mastodon.example",
+        "access_token": "YOUR_TOKEN"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a Mastodon section to `config.sample.json`
- document how to configure Mastodon accounts in `README.md`

## Testing
- `python -m py_compile server.py test_api_request.py`

------
https://chatgpt.com/codex/tasks/task_e_688327c77dd48329a19e8745e5e94d05