### PR TITLE
Add Mastodon.py and requests to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A simple REST API that receives post requests and forwards them to various servi
        }
    }
    ```
-2. Install dependencies:
+2. Install dependencies. The project uses `Mastodon.py` and `requests`, so run:
    ```bash
    pip install -r requirements.txt
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+Mastodon.py
+requests


### PR DESCRIPTION
## Summary
- add Mastodon.py and requests to the dependency list
- note new dependencies in setup instructions

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile server.py test_api_request.py`


------
https://chatgpt.com/codex/tasks/task_e_688329cd660c83299a9ca2398afc802c