### PR TITLE
Add Mastodon posting support

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,6 +2,8 @@ import json
 from pathlib import Path
 from typing import List, Optional
 
+import base64
+from io import BytesIO
 from mastodon import Mastodon
 
 from fastapi import FastAPI
@@ -18,6 +20,25 @@ else:
 
 app = FastAPI(title="autoPoster")
 
+
+def create_mastodon_clients():
+    """Create Mastodon clients for all configured accounts."""
+    clients = {}
+    accounts = CONFIG.get("mastodon", {}).get("accounts", {})
+    for name, info in accounts.items():
+        try:
+            clients[name] = Mastodon(
+                access_token=info["access_token"],
+                api_base_url=info["instance_url"],
+            )
+        except Exception as exc:
+            # Log error but continue creating other clients
+            print(f"Failed to init Mastodon client for {name}: {exc}")
+    return clients
+
+
+MASTODON_CLIENTS = create_mastodon_clients()
+
 class PostRequest(BaseModel):
     text: str
     media: Optional[List[str]] = None  # base64 encoded strings
@@ -27,6 +48,29 @@ class MastodonPostRequest(BaseModel):
     account: str
     text: str
     media: Optional[List[str]] = None
+
+
+def post_to_mastodon(account: str, text: str, media: Optional[List[str]] = None):
+    client = MASTODON_CLIENTS.get(account)
+    if not client:
+        return {"error": "Account not configured"}
+
+    media_ids = None
+    if media:
+        media_ids = []
+        for item in media:
+            try:
+                uploaded = client.media_post(item)
+                media_ids.append(uploaded.get("id"))
+            except Exception as exc:
+                return {"error": f"Media upload failed: {exc}"}
+
+    try:
+        client.status_post(text, media_ids=media_ids)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+    return {"posted": True}
 
 @app.get("/")
 async def root():
@@ -41,18 +85,7 @@ async def receive_post(data: PostRequest):
 
 @app.post("/mastodon/post")
 async def mastodon_post(data: MastodonPostRequest):
-    accounts = CONFIG.get("mastodon", {}).get("accounts", {})
-    account_conf = accounts.get(data.account)
-    if not account_conf:
-        return {"error": "Account not configured"}
-
-    client = Mastodon(
-        access_token=account_conf["access_token"],
-        api_base_url=account_conf["instance_url"],
-    )
-
-    client.status_post(data.text, media_ids=None)
-    return {"posted": True}
+    return post_to_mastodon(data.account, data.text, data.media)
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary
- configure Mastodon clients on startup
- add helper to post to Mastodon with media uploads
- expose `/mastodon/post` endpoint using this helper
- adjust Mastodon tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688332849734832998ea0140f6f84840