### PR TITLE
Add pytest/httpx setup info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ A simple REST API that receives post requests and forwards them to various servi
        }
    }
    ```
-2. Install dependencies. The project uses `Mastodon.py` and `requests`, so run:
+2. Install dependencies. The project uses `Mastodon.py` and `requests`; the test
+   suite relies on `pytest` and `httpx`. Install everything with:
    ```bash
    pip install -r requirements.txt
    ```
@@ -26,6 +27,10 @@ A simple REST API that receives post requests and forwards them to various servi
    python server.py
    ```
    The API will start on `http://localhost:8765`.
+4. To execute the tests, run:
+   ```bash
+   pytest
+   ```
 
 ## API
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 Mastodon.py
 requests
+pytest
+httpx


### PR DESCRIPTION
## Summary
- add `pytest` and `httpx` to requirements
- document installing them and how to run tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884593be6708329840ddfe7f434d353