### PR TITLE
Improve config validation for Mastodon accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,17 @@ curl -X POST http://localhost:8765/mastodon/post \
      -d '{"account": "account1", "text": "Hello world", "media": ["b64"]}'
 ```
 
+## Troubleshooting
+
+If requests to `/mastodon/post` return `{ "error": "Account misconfigured" }`,
+the server detected problems with your Mastodon configuration during startup.
+Common issues include:
+
+* `mastodon.accounts` is missing or empty in `config.json`.
+* An account is missing `instance_url` or `access_token` fields.
+* Placeholder values such as `https://mastodon.example` or `YOUR_TOKEN` are
+  still present.
+
+Check the server logs for messages like `Mastodon config error for account1` and
+update `config.json` with the correct information before restarting the server.
+


### PR DESCRIPTION
## Summary
- add `validate_mastodon_accounts` to check config before creating clients
- log and store validation errors so posting can detect misconfigured accounts
- return `{"error": "Account misconfigured"}` when posting to a bad account
- update README with troubleshooting section
- extend tests for the new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68845b3c1c1883298b5da5ec4f139e98