### PR TITLE
Add configuration checks to tests

### DIFF
--- a/test_api_request.py
+++ b/test_api_request.py
@@ -1,5 +1,17 @@
 import json
 import urllib.request
+from pathlib import Path
+
+import pytest
+
+CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
+
+
+def test_config_exists():
+    """Ensure config.json is present before running API tests."""
+    if not CONFIG_PATH.exists():
+        pytest.fail("config.json not found. Please create it before running tests.")
+
 
 
 def main():

--- a/test_mastodon_post.py
+++ b/test_mastodon_post.py
@@ -1,6 +1,18 @@
 import json
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
+
+CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
+
+if not CONFIG_PATH.exists():
+    pytest.fail("config.json not found. Please create it with Mastodon account information before running tests.")
+else:
+    with CONFIG_PATH.open() as fh:
+        _cfg = json.load(fh)
+    if not _cfg.get("mastodon", {}).get("accounts"):
+        pytest.fail("No Mastodon accounts configured in config.json.")
 
 import server
 


### PR DESCRIPTION
## Summary
- ensure `pytest test_api_request` fails if `config.json` is missing
- fail `test_mastodon_post` when `config.json` lacks Mastodon account details

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: config.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68845ed007cc8329a1a9bf6cc5197e57