### PR TITLE
Add sample script for local Mastodon post

### DIFF
--- a/send_mastodon_post.py
+++ b/send_mastodon_post.py
@@ -1,0 +1,29 @@
+import base64
+import json
+import requests
+
+URL = "http://localhost:8765/mastodon/post"
+ACCOUNT = "account1"  # must match an entry in config.json
+TEXT = "これは自動投稿のテストです"
+MEDIA_PATH = "/path/to/image.png"  # replace with an actual file path
+
+
+def main():
+    # Read the media file and encode as base64
+    with open(MEDIA_PATH, "rb") as f:
+        media_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+    payload = {
+        "account": ACCOUNT,
+        "text": TEXT,
+        "media": [media_b64],
+    }
+
+    headers = {"Content-Type": "application/json"}
+    resp = requests.post(URL, data=json.dumps(payload), headers=headers)
+    print(f"Status: {resp.status_code}")
+    print(f"Response: {resp.text}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `send_mastodon_post.py` as an example script to send a request to the API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688462a35b308329ba1b5b2e47f44e53