### PR TITLE
Decode Mastodon media uploads

### DIFF
--- a/server.py
+++ b/server.py
@@ -98,7 +98,8 @@ def post_to_mastodon(account: str, text: str, media: Optional[List[str]] = None)
         media_ids = []
         for item in media:
             try:
-                uploaded = client.media_post(item)
+                data = base64.b64decode(item)
+                uploaded = client.media_post(BytesIO(data))
                 media_ids.append(uploaded.get("id"))
             except Exception as exc:
                 return {"error": f"Media upload failed: {exc}"}


### PR DESCRIPTION
## Summary
- decode media uploads before sending to Mastodon
- adjust tests for decoded media

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68846c66150483299806a9a641e531a1