### PR TITLE
Remove config.json requirement from tests

### DIFF
--- a/test_api_request.py
+++ b/test_api_request.py
@@ -1,35 +1,13 @@
-import json
-import urllib.request
-from pathlib import Path
+from fastapi.testclient import TestClient
 
-import pytest
+import server
 
-CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
+pytest_plugins = ["test_mastodon_post"]
 
 
-def test_config_exists():
-    """Ensure config.json is present before running API tests."""
-    if not CONFIG_PATH.exists():
-        pytest.fail("config.json not found. Please create it before running tests.")
-
-
-
-def main():
-    url = "http://localhost:8765/post"
-    payload = {"text": "test"}
-    data = json.dumps(payload).encode("utf-8")
-    headers = {"Content-Type": "application/json"}
-
-    print(f"Sending POST request to {url} with payload: {payload}")
-    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
-    try:
-        with urllib.request.urlopen(req) as response:
-            body = response.read().decode("utf-8")
-            print(f"Response status: {response.status}")
-            print(f"Response body: {body}")
-    except Exception as exc:
-        print(f"Request failed: {exc}")
-
-
-if __name__ == "__main__":
-    main()
+def test_post_endpoint(temp_config):
+    """Verify the generic /post endpoint works with a temp config."""
+    client = TestClient(server.app)
+    resp = client.post("/post", json={"text": "test", "media": ["a"]})
+    assert resp.status_code == 200
+    assert resp.json() == {"received": True, "media_items": 1}

--- a/test_mastodon_post.py
+++ b/test_mastodon_post.py
@@ -1,20 +1,9 @@
 import json
-from pathlib import Path
 import base64
 from io import BytesIO
 
 import pytest
 from fastapi.testclient import TestClient
-
-CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
-
-if not CONFIG_PATH.exists():
-    pytest.fail("config.json not found. Please create it with Mastodon account information before running tests.")
-else:
-    with CONFIG_PATH.open() as fh:
-        _cfg = json.load(fh)
-    if not _cfg.get("mastodon", {}).get("accounts"):
-        pytest.fail("No Mastodon accounts configured in config.json.")
 
 import server
 


### PR DESCRIPTION
## Summary
- drop unnecessary config.json check from mastodon tests
- update API test to use fixtures and verify `/post` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68846d6a2fec8329a8631f64d7489688