### PR TITLE
Update Mastodon media docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ of `config.json`.
 ```
 
 `media` is optional and should be a list of base64 encoded strings representing
-the files you want uploaded alongside the toot.
+the files you want uploaded alongside the toot. The server decodes each
+element, then uploads the bytes to Mastodon using `media_post`. No explicit
+size or type validation is performed, so keep each file within the limits
+accepted by your Mastodon instance (often up to around 40 MB for images or
+video) and in a supported format such as PNG, JPEG, GIF or MP4.
 
 Example using `curl`:
 


### PR DESCRIPTION
## Summary
- document that `/mastodon/post` takes base64 media
- note that the server decodes and uploads to Mastodon with no extra validation
- mention typical Mastodon limits and formats

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68846f01f33c8329885e3d303ed1c6b1