### PR TITLE
Add MIME type when uploading Mastodon media

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ of `config.json`.
 
 `media` is optional and should be a list of base64 encoded strings representing
 the files you want uploaded alongside the toot. The server decodes each
-element, then uploads the bytes to Mastodon using `media_post`. No explicit
-size or type validation is performed, so keep each file within the limits
+element, then uploads the bytes to Mastodon using `media_post`. If no MIME type
+is specified for the upload, the server defaults to `application/octet-stream`.
+No explicit size or type validation is performed, so keep each file within the limits
 accepted by your Mastodon instance (often up to around 40 MB for images or
 video) and in a supported format such as PNG, JPEG, GIF or MP4.
 

--- a/server.py
+++ b/server.py
@@ -99,7 +99,7 @@ def post_to_mastodon(account: str, text: str, media: Optional[List[str]] = None)
         for item in media:
             try:
                 data = base64.b64decode(item)
-                uploaded = client.media_post(BytesIO(data))
+                uploaded = client.media_post(BytesIO(data), mime_type="application/octet-stream")
                 media_ids.append(uploaded.get("id"))
             except Exception as exc:
                 return {"error": f"Media upload failed: {exc}"}

--- a/test_mastodon_post.py
+++ b/test_mastodon_post.py
@@ -12,14 +12,16 @@ class DummyMastodon:
         self.init_args = kwargs
         self.posts = []
         self.media = []
+        self.media_types = []
         self.next_id = 1
 
     def status_post(self, text, media_ids=None):
         self.posts.append({'text': text, 'media_ids': media_ids})
         return {'id': 1}
 
-    def media_post(self, data):
+    def media_post(self, data, mime_type=None):
         self.media.append(data)
+        self.media_types.append(mime_type)
         mid = self.next_id
         self.next_id += 1
         return {'id': mid}
@@ -84,6 +86,7 @@ def test_post_with_media(monkeypatch, temp_config):
     assert dummy.posts[0]['text'] == 'hi'
     assert isinstance(dummy.media[0], BytesIO)
     assert dummy.media[0].read() == data
+    assert dummy.media_types[0] == "application/octet-stream"
     assert dummy.posts[0]['media_ids'] == [1]
 
 def test_invalid_account(monkeypatch, temp_config):


### PR DESCRIPTION
## Summary
- default to `application/octet-stream` for Mastodon media uploads
- track MIME type in DummyMastodon for tests
- verify MIME type in tests
- document default MIME type in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68847186047083299b8a54367bf729b1