### PR TITLE
Add Twitter config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ A simple REST API that receives post requests and forwards them to various servi
                "access_token": "YOUR_TOKEN"
            }
        }
+    }
+    ```
+   To configure Twitter accounts, add a `twitter` section with credentials for
+   each account:
+
+   ```json
+   "twitter": {
+       "accounts": {
+           "account1": {
+               "consumer_key": "YOUR_CONSUMER_KEY",
+               "consumer_secret": "YOUR_CONSUMER_SECRET",
+               "access_token": "YOUR_ACCESS_TOKEN",
+               "access_token_secret": "YOUR_ACCESS_TOKEN_SECRET",
+               "bearer_token": "YOUR_BEARER_TOKEN"
+           }
+       }
    }
    ```
 2. Install dependencies. The project uses `Mastodon.py` and `requests`; the test

--- a/config.sample.json
+++ b/config.sample.json
@@ -10,5 +10,16 @@
         "access_token": "YOUR_TOKEN"
       }
     }
+  },
+  "twitter": {
+    "accounts": {
+      "account1": {
+        "consumer_key": "YOUR_CONSUMER_KEY",
+        "consumer_secret": "YOUR_CONSUMER_SECRET",
+        "access_token": "YOUR_ACCESS_TOKEN",
+        "access_token_secret": "YOUR_ACCESS_TOKEN_SECRET",
+        "bearer_token": "YOUR_BEARER_TOKEN"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- extend `config.sample.json` with a `twitter` section for account credentials
- document the `twitter` section in `README.md`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884844aacc08329ab4fe7472fde0e50