### PR TITLE
Add Note account config handling

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -1,7 +1,11 @@
 {
   "note": {
-    "username": "your_username",
-    "password": "your_password"
+    "accounts": {
+      "account1": {
+        "username": "your_username",
+        "password": "your_password"
+      }
+    }
   },
   "mastodon": {
     "accounts": {


### PR DESCRIPTION
## Summary
- extend `config.sample.json` with a new `note.accounts` section
- parse and validate `note` accounts in `server.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68872033de088329873a93ceb68eeb37