### PR TITLE
Add note.com posting support

### DIFF
--- a/server.py
+++ b/server.py
@@ -231,6 +231,15 @@ class TwitterPostRequest(BaseModel):
     media: Optional[List[str]] = None
 
 
+class NotePostRequest(BaseModel):
+    account: str
+    text: str
+    media: Optional[List[str]] = None
+    thumbnail: Optional[str] = None
+    paid: bool
+    tags: Optional[List[str]] = None
+
+
 def post_to_mastodon(account: str, text: str, media: Optional[List[str]] = None):
     if account in MASTODON_ACCOUNT_ERRORS:
         return {"error": "Account misconfigured"}
@@ -380,6 +389,18 @@ async def mastodon_post(data: MastodonPostRequest):
 @app.post("/twitter/post")
 async def twitter_post(data: TwitterPostRequest):
     return post_to_twitter(data.account, data.text, data.media)
+
+
+@app.post("/note/post")
+async def note_post(data: NotePostRequest):
+    return post_to_note(
+        data.account,
+        data.text,
+        data.media or [],
+        data.thumbnail or "",
+        data.paid,
+        data.tags or [],
+    )
 
 if __name__ == "__main__":
     import uvicorn

--- a/test_api_request.py
+++ b/test_api_request.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 import server
 
-pytest_plugins = ["test_mastodon_post", "test_twitter_post"]
+pytest_plugins = ["test_mastodon_post", "test_twitter_post", "test_note_post"]
 
 
 def test_post_endpoint(temp_config):

--- a/test_note_post.py
+++ b/test_note_post.py
@@ -1,0 +1,57 @@
+import server
+from fastapi.testclient import TestClient
+
+
+def make_client(monkeypatch, return_value=None):
+    called = {}
+
+    def dummy(account, text, media, thumbnail, paid, tags):
+        called['args'] = (account, text, media, thumbnail, paid, tags)
+        return return_value if return_value is not None else {"posted": True}
+
+    monkeypatch.setattr(server, "post_to_note", dummy)
+    return TestClient(server.app), called
+
+
+def test_note_post(monkeypatch):
+    client, called = make_client(monkeypatch)
+    payload = {
+        "account": "acc",
+        "text": "hello",
+        "media": ["m1"],
+        "thumbnail": "thumb",
+        "paid": False,
+        "tags": ["t1", "t2"],
+    }
+    resp = client.post("/note/post", json=payload)
+    assert resp.status_code == 200
+    assert resp.json() == {"posted": True}
+    assert called["args"] == (
+        "acc",
+        "hello",
+        ["m1"],
+        "thumb",
+        False,
+        ["t1", "t2"],
+    )
+
+
+def test_note_post_defaults(monkeypatch):
+    client, called = make_client(monkeypatch)
+    payload = {
+        "account": "acc",
+        "text": "hello",
+        "paid": True,
+    }
+    resp = client.post("/note/post", json=payload)
+    assert resp.status_code == 200
+    assert resp.json() == {"posted": True}
+    assert called["args"] == ("acc", "hello", [], "", True, [])
+
+
+def test_note_post_error(monkeypatch):
+    client, _ = make_client(monkeypatch, return_value={"error": "fail"})
+    payload = {"account": "acc", "text": "x", "paid": False}
+    resp = client.post("/note/post", json=payload)
+    assert resp.status_code == 200
+    assert resp.json() == {"error": "fail"}


### PR DESCRIPTION
## Summary
- support posting to Note with new `NotePostRequest` model
- expose `/note/post` endpoint
- test the new route and defaults

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688721fcc0048329a1ff29cbe2e92dfa