### PR TITLE
Add script for note posting

### DIFF
--- a/send_note_post.py
+++ b/send_note_post.py
@@ -1,0 +1,39 @@
+import base64
+import json
+import requests
+
+URL = "http://localhost:8765/note/post"
+ACCOUNT = "account1"  # must match an entry in config.json
+TEXT = "これはnoteへの自動投稿テストです"
+THUMBNAIL_PATH = "/path/to/thumbnail.png"  # replace with an actual file path
+MEDIA_PATHS = ["/path/to/image1.png", "/path/to/image2.png"]  # optional additional images
+PAID = False
+TAGS = ["test", "auto"]
+
+
+def _encode_file(path: str) -> str:
+    with open(path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+
+def main():
+    thumbnail_b64 = _encode_file(THUMBNAIL_PATH) if THUMBNAIL_PATH else ""
+    media_b64 = [_encode_file(p) for p in MEDIA_PATHS if p]
+
+    payload = {
+        "account": ACCOUNT,
+        "text": TEXT,
+        "media": media_b64,
+        "thumbnail": thumbnail_b64,
+        "paid": PAID,
+        "tags": TAGS,
+    }
+
+    headers = {"Content-Type": "application/json"}
+    resp = requests.post(URL, data=json.dumps(payload), headers=headers)
+    print(f"Status: {resp.status_code}")
+    print(f"Response: {resp.text}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `send_note_post.py` script for posting to `/note/post`
- demonstrate encoding thumbnail and optional images

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688722a883c08329b07f1ec0b5baaf7b