### PR TITLE
Add note post route tests

### DIFF
--- a/test_api_request.py
+++ b/test_api_request.py
@@ -2,7 +2,12 @@ from fastapi.testclient import TestClient
 
 import server
 
-pytest_plugins = ["test_mastodon_post", "test_twitter_post", "test_note_post"]
+pytest_plugins = [
+    "test_mastodon_post",
+    "test_twitter_post",
+    "test_note_post",
+    "test_note_post_route",
+]
 
 
 def test_post_endpoint(temp_config):


### PR DESCRIPTION
## Summary
- test `/note/post` with a dummy Selenium driver
- ensure misconfigured note accounts return an error
- register the new test module in `pytest_plugins`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68872322289c83298dda949bc3161181