### PR TITLE
Add Note docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ A simple REST API that receives post requests and forwards them to various servi
    pytest
    ```
 
+## Note
+
+To automate posts on [note.com](https://note.com), add a `note` section to
+`config.json` describing each account:
+
+```json
+"note": {
+    "accounts": {
+        "account1": {
+            "username": "your_username",
+            "password": "your_password"
+        }
+    }
+}
+```
+
+The server uses Selenium with headless Chrome to publish notes. Install Google
+Chrome and a matching **ChromeDriver** (or another WebDriver such as
+geckodriver) and ensure the driver binary is available on your `PATH`. You do
+not need to run the driver yourself&mdash;`server.py` launches it automatically
+when a request to `/note/post` is processed.
+
 ## API
 
 ### `POST /post`
@@ -122,6 +144,42 @@ Example using `curl`:
 curl -X POST http://localhost:8765/twitter/post \
      -H 'Content-Type: application/json' \
      -d '{"account": "account1", "text": "Hello Twitter", "media": ["b64"]}'
+```
+
+### `POST /note/post`
+
+Post to one of the configured Note accounts. The JSON payload must include the
+`account` key matching an entry under `note.accounts` in `config.json`.
+
+```json
+{
+  "account": "account1",
+  "text": "Hello Note",
+  "media": ["base64image"],
+  "thumbnail": "base64thumb",
+  "paid": true,
+  "tags": ["tag1", "tag2"]
+}
+```
+
+`thumbnail` is optional and should contain a base64 encoded image used as the
+post's thumbnail. Set `paid` to `true` to publish a paid note or `false` for a
+free note. `tags` is optional and accepts a list of tags.
+
+Example paid post:
+
+```bash
+curl -X POST http://localhost:8765/note/post \
+     -H 'Content-Type: application/json' \
+     -d '{"account": "account1", "text": "Hello Note", "thumbnail": "b64thumb", "paid": true, "tags": ["tag1", "tag2"]}'
+```
+
+Example free post:
+
+```bash
+curl -X POST http://localhost:8765/note/post \
+     -H 'Content-Type: application/json' \
+     -d '{"account": "account1", "text": "Another Note", "paid": false, "tags": []}'
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- document note.com config and WebDriver usage
- describe the note posting endpoint and provide curl examples

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887240aca148329af272e027764466c