### PR TITLE
Improve login automation

### DIFF
--- a/server.py
+++ b/server.py
@@ -349,7 +349,9 @@ def post_to_note(
             wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, NOTE_SELECTORS["login_username"])))
             driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_username"]).send_keys(creds["username"])
             driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_password"]).send_keys(creds["password"])
-            driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_submit"]).click()
+            login_button = driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_submit"])
+            wait.until(lambda d: login_button.is_enabled())
+            login_button.click()
             wait.until(EC.url_contains("/"))
         except Exception as exc:
             path = _capture_screenshot()

--- a/test_note_post_route.py
+++ b/test_note_post_route.py
@@ -8,6 +8,8 @@ class DummyElement:
         pass
     def click(self):
         pass
+    def is_enabled(self):
+        return True
 
 class DummyDriver:
     def __init__(self, fail=None, *args, **kwargs):


### PR DESCRIPTION
## Summary
- wait for the login button to become enabled before clicking
- extend dummy element in tests with `is_enabled`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887666148b48329bad3f2f47bcbba39