### PR TITLE
Improve Note login stability

### DIFF
--- a/server.py
+++ b/server.py
@@ -140,7 +140,7 @@ NOTE_SELECTORS = {
     # After login we navigate to the home page then open the editor via the
     # 「投稿」 button. The old ``/notes/new`` URL no longer works directly.
     "home_url": "https://note.com/",
-    "post_menu": "//a[contains(., '投稿')]",
+    "post_menu": "//*[self::a or self::button][contains(., '投稿')]",
     "new_post_menu": "//span[contains(., '新しく記事を書く')]",
 
     # Editor fields use contenteditable DIVs instead of textareas.
@@ -363,10 +363,34 @@ def post_to_note(
         # --- Login step ---
         try:
             driver.get("https://note.com/login")
-            wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, NOTE_SELECTORS["login_username"])))
-            driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_username"]).send_keys(creds["username"])
-            driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_password"]).send_keys(creds["password"])
-            driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_submit"]).click()
+            wait.until(
+                EC.presence_of_element_located(
+                    (By.CSS_SELECTOR, NOTE_SELECTORS["login_username"])
+                )
+            )
+            username_field = driver.find_element(
+                By.CSS_SELECTOR, NOTE_SELECTORS["login_username"]
+            )
+            username_field.clear()
+            username_field.send_keys(creds["username"])
+            password_field = driver.find_element(
+                By.CSS_SELECTOR, NOTE_SELECTORS["login_password"]
+            )
+            password_field.clear()
+            password_field.send_keys(creds["password"])
+
+            # Wait until the login button becomes enabled before clicking
+            wait.until(
+                lambda d: d.find_element(
+                    By.CSS_SELECTOR, NOTE_SELECTORS["login_submit"]
+                ).is_enabled()
+            )
+            login_button = driver.find_element(
+                By.CSS_SELECTOR, NOTE_SELECTORS["login_submit"]
+            )
+            login_button.click()
+            # Sometimes the first click is missed; send a second one
+            login_button.click()
             wait.until(EC.url_contains("/"))
         except Exception as exc:
             path = _capture_screenshot()

--- a/test_note_post_route.py
+++ b/test_note_post_route.py
@@ -6,8 +6,12 @@ import pytest
 class DummyElement:
     def send_keys(self, *args, **kwargs):
         pass
+    def clear(self):
+        pass
     def click(self):
         pass
+    def is_enabled(self):
+        return True
 
 class DummyDriver:
     def __init__(self, fail=None, *args, **kwargs):


### PR DESCRIPTION
## Summary
- tweak NOTE post selector to handle <button>
- wait for login submit button to be enabled
- clear fields before entering credentials and double‑click to avoid missed clicks
- extend DummyElement in tests for compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68881abbd180832993bfdef8b735a6a4