### PR TITLE
Fix note login redirect

### DIFF
--- a/server.py
+++ b/server.py
@@ -15,6 +15,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+import urllib.parse
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -134,10 +135,10 @@ NOTE_ACCOUNTS = load_note_accounts()
 
 # CSS selectors and URLs used to automate posting to Note
 NOTE_SELECTORS = {
+    "login_url": "https://note.com/login?redirectPath=",
     "login_username": "#email",
     "login_password": "#password",
     "login_submit": ".o-login__button button",
-    "login_link": "//*[self::a or self::button][contains(., 'ログイン')]",
     # After login we navigate to the home page then open the editor via the
     # 「投稿」 button. The old ``/notes/new`` URL no longer works directly.
     "home_url": "https://note.com/",
@@ -363,12 +364,11 @@ def post_to_note(
 
         # --- Login step ---
         try:
-            # Open the top page and click the login link to display the form
-            driver.get(NOTE_SELECTORS["home_url"])
-            wait.until(
-                EC.element_to_be_clickable((By.XPATH, NOTE_SELECTORS["login_link"]))
+            # Load the login page directly with a redirectPath parameter so the form shows
+            login_url = NOTE_SELECTORS["login_url"] + urllib.parse.quote(
+                NOTE_SELECTORS["home_url"]
             )
-            driver.find_element(By.XPATH, NOTE_SELECTORS["login_link"]).click()
+            driver.get(login_url)
             # Wait for the login form fields to appear
             wait.until(
                 EC.presence_of_element_located(


### PR DESCRIPTION
## Summary
- add `login_url` with `redirectPath` in selectors
- load login page using this URL in `post_to_note`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888218687048329b1bf52807450b0fa