### PR TITLE
Add visible Selenium option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ A simple REST API that receives post requests and forwards them to various servi
    python server.py
    ```
    The API will start on `http://localhost:8765`.
+   Use `--show-browser` if you want to see the Selenium browser window when
+   posting to note.com:
+   ```bash
+   python server.py --show-browser
+   ```
 5. To execute the tests, run:
    ```bash
    pytest

--- a/server.py
+++ b/server.py
@@ -31,6 +31,11 @@ else:
 
 app = FastAPI(title="autoPoster")
 
+# By default Selenium runs in headless mode.  When the server is started with
+# the --show-browser flag this global is set to False so a visible browser is
+# launched instead.
+HEADLESS = True
+
 
 def validate_mastodon_accounts(config: Dict) -> Dict[str, str]:
     """Validate Mastodon account configuration and return a map of errors."""
@@ -344,7 +349,8 @@ def post_to_note(
         return {"error": "Account not configured"}
 
     options = ChromeOptions()
-    options.add_argument("--headless")
+    if HEADLESS:
+        options.add_argument("--headless")
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-dev-shm-usage")
     print("[NOTE] Launching Chrome")
@@ -514,6 +520,18 @@ async def note_post(data: NotePostRequest):
     )
 
 if __name__ == "__main__":
+    import argparse
     import uvicorn
+
+    parser = argparse.ArgumentParser(description="autoPoster server")
+    parser.add_argument(
+        "--show-browser",
+        action="store_true",
+        help="Launch Selenium with a visible browser window",
+    )
+    args = parser.parse_args()
+
+    if args.show_browser:
+        HEADLESS = False
 
     uvicorn.run(app, host="127.0.0.1", port=8765)


### PR DESCRIPTION
## Summary
- make Selenium headless mode configurable
- add `--show-browser` argument to the server
- document the new option in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882463c2f8832998c04752e9b2955e