### PR TITLE
Fix Note image uploads

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Any
 
 import os
 import tempfile
@@ -170,6 +170,9 @@ NOTE_SELECTORS = {
 
     # File inputs appear after clicking their respective UI controls.
     "media_input": "input[type='file']",
+    # Body image uploads require clicking the "画像を追加" button to create a new
+    # file input.
+    "media_button": "//button[contains(@aria-label, '画像を追加')]",
     "thumbnail_button": "//button[contains(@aria-label, '画像をアップロード')]",
     "thumbnail_input": "input[type='file']",
 
@@ -386,6 +389,14 @@ def post_to_note(
         print(f"[NOTE] {msg}; screenshot {path}")
         return {"error": msg, "screenshot": path}
 
+    def _send_to_new_input(input_selector: str, path: str, trigger: Optional[Any] = None):
+        """Wait for a new file input to appear and send the file path."""
+        existing = driver.find_elements(By.CSS_SELECTOR, input_selector)
+        if trigger is not None:
+            trigger.click()
+        wait.until(lambda d: len(d.find_elements(By.CSS_SELECTOR, input_selector)) > len(existing))
+        driver.find_elements(By.CSS_SELECTOR, input_selector)[-1].send_keys(path)
+
     try:
         wait = WebDriverWait(driver, 20)
 
@@ -469,7 +480,8 @@ def post_to_note(
             try:
                 print("[NOTE] Uploading media item")
                 path_f = _temp_file_from_b64(item)
-                driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["media_input"]).send_keys(path_f)
+                button = driver.find_element(By.XPATH, NOTE_SELECTORS["media_button"])
+                _send_to_new_input(NOTE_SELECTORS["media_input"], path_f, button)
                 print("[NOTE] Media item uploaded")
             except Exception as exc:
                 return _fail_step("upload media", exc)
@@ -480,11 +492,8 @@ def post_to_note(
             try:
                 print("[NOTE] Uploading thumbnail")
                 path_f = _temp_file_from_b64(thumbnail)
-                driver.find_element(By.XPATH, NOTE_SELECTORS["thumbnail_button"]).click()
-                wait.until(
-                    EC.presence_of_element_located((By.CSS_SELECTOR, NOTE_SELECTORS["thumbnail_input"]))
-                )
-                driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["thumbnail_input"]).send_keys(path_f)
+                button = driver.find_element(By.XPATH, NOTE_SELECTORS["thumbnail_button"])
+                _send_to_new_input(NOTE_SELECTORS["thumbnail_input"], path_f, button)
                 print("[NOTE] Thumbnail uploaded")
             except Exception as exc:
                 return _fail_step("upload thumbnail", exc)

--- a/test_note_post_route.py
+++ b/test_note_post_route.py
@@ -24,6 +24,11 @@ class DummyDriver:
         if selector == self.fail:
             raise Exception('missing')
         return DummyElement()
+    def find_elements(self, by, selector, *args, **kwargs):
+        self.actions.append(('find_all', selector))
+        if selector == self.fail:
+            return []
+        return [DummyElement()]
     def save_screenshot(self, path):
         self.actions.append(('screenshot', path))
         with open(path, 'wb') as fh:
@@ -33,8 +38,13 @@ class DummyDriver:
 
 class DummyWait:
     def __init__(self, driver, timeout):
-        pass
+        self.driver = driver
     def until(self, condition):
+        if callable(condition):
+            try:
+                condition(self.driver)
+            except Exception:
+                pass
         return True
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- wait for a new file input when uploading images to Note
- click the "画像を追加" button before sending files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888596f79208329ad17693e29ab6adf