### PR TITLE
Add wait before clicking Note publish button

### DIFF
--- a/server.py
+++ b/server.py
@@ -523,6 +523,11 @@ def post_to_note(
 
         # --- Publish step ---
         try:
+            wait.until(
+                EC.element_to_be_clickable(
+                    (By.XPATH, NOTE_SELECTORS["publish_next"])
+                )
+            )
             driver.find_element(By.XPATH, NOTE_SELECTORS["publish_next"]).click()
             print("[NOTE] Proceeding to publish")
             wait.until(


### PR DESCRIPTION
## Summary
- ensure Selenium waits for the "公開に進む" button to be clickable before clicking
- keep existing publish logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68887bbace848329b953dd8c45b75fa8