### PR TITLE
Refactor server into service modules

### DIFF
--- a/mastodon_service.py
+++ b/mastodon_service.py
@@ -1,0 +1,85 @@
+import base64
+from io import BytesIO
+from typing import Dict, List, Optional
+
+from mastodon import Mastodon
+
+
+def validate_accounts(config: Dict) -> Dict[str, str]:
+    """Validate Mastodon account configuration and return a map of errors."""
+    errors: Dict[str, str] = {}
+    accounts = config.get("mastodon", {}).get("accounts")
+    if not accounts:
+        errors["_general"] = "mastodon.accounts section missing or empty"
+        return errors
+
+    for name, info in accounts.items():
+        account_errors = []
+        instance = info.get("instance_url")
+        token = info.get("access_token")
+
+        if not instance:
+            account_errors.append("missing instance_url")
+        elif "mastodon.example" in instance:
+            account_errors.append("instance_url looks like a placeholder")
+
+        if not token:
+            account_errors.append("missing access_token")
+        elif token == "YOUR_TOKEN":
+            account_errors.append("access_token looks like a placeholder")
+
+        if account_errors:
+            errors[name] = "; ".join(account_errors)
+    return errors
+
+
+def create_clients(config: Dict, account_errors: Dict[str, str]):
+    """Create Mastodon clients for all configured accounts."""
+    clients = {}
+    accounts = config.get("mastodon", {}).get("accounts", {})
+    for name, info in accounts.items():
+        if name in account_errors:
+            continue
+        try:
+            clients[name] = Mastodon(
+                access_token=info["access_token"],
+                api_base_url=info["instance_url"],
+            )
+        except Exception as exc:
+            # Log error but continue creating other clients
+            print(f"Failed to init Mastodon client for {name}: {exc}")
+    return clients
+
+
+def post_to_mastodon(
+    account: str,
+    text: str,
+    media: Optional[List[str]] = None,
+    *,
+    clients: Dict[str, Mastodon],
+    account_errors: Dict[str, str],
+):
+    """Post a toot with optional media."""
+    if account in account_errors:
+        return {"error": "Account misconfigured"}
+    client = clients.get(account)
+    if not client:
+        return {"error": "Account not configured"}
+
+    media_ids = None
+    if media:
+        media_ids = []
+        for item in media:
+            try:
+                data = base64.b64decode(item)
+                uploaded = client.media_post(BytesIO(data), mime_type="application/octet-stream")
+                media_ids.append(uploaded.get("id"))
+            except Exception as exc:
+                return {"error": f"Media upload failed: {exc}"}
+
+    try:
+        client.status_post(text, media_ids=media_ids)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+    return {"posted": True}

--- a/note_service.py
+++ b/note_service.py
@@ -1,0 +1,283 @@
+import base64
+import os
+import tempfile
+import urllib.parse
+from io import BytesIO
+from typing import Any, Dict, List, Optional
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+# By default Selenium runs in headless mode. It can be toggled via the
+# HEADLESS variable which the server updates when started with --show-browser.
+HEADLESS = True
+
+# CSS selectors and URLs used to automate posting to Note
+NOTE_SELECTORS = {
+    "login_url": "https://note.com/login?redirectPath=",
+    "login_username": "#email",
+    "login_password": "#password",
+    "login_submit": ".o-login__button button",
+    "home_url": "https://note.com/",
+    "post_menu": "//*[self::button or self::a][contains(., '投稿')]",
+    "new_post_menu": (
+        "//*[self::button or self::a][contains(., '新しく記事を書く')"
+        " or contains(@href, '/notes/new')]"
+    ),
+    "editor_title": "textarea[placeholder='記事タイトル'], div[data-placeholder='記事タイトル']",
+    "title_area": "textarea[placeholder='記事タイトル'], div[data-placeholder='記事タイトル']",
+    "text_area": "div[contenteditable='true'][role='textbox']",
+    "media_input": "input[type='file']",
+    "media_button": "//button[contains(@aria-label, '画像') or contains(., '画像')]",
+    "thumbnail_button": (
+        "//button[contains(@aria-label, '画像をアップロード') or "
+        "contains(., '画像をアップロード')]"
+    ),
+    "thumbnail_input": "input[type='file']",
+    "paid_tab": "//label[contains(., '有料')]/input",
+    "free_tab": "//label[contains(., '無料')]/input",
+    "tag_input": "input[placeholder='ハッシュタグを追加する']",
+    "publish_next": "//button[contains(., '公開に進む')]",
+    "publish": "//button[contains(., '投稿する') or contains(., '更新する')]",
+}
+
+
+def validate_accounts(config: Dict) -> Dict[str, str]:
+    """Validate Note account configuration and return a map of errors."""
+    errors: Dict[str, str] = {}
+    accounts = config.get("note", {}).get("accounts")
+    if not accounts:
+        errors["_general"] = "note.accounts section missing or empty"
+        return errors
+
+    placeholders = {
+        "username": "your_username",
+        "password": "your_password",
+    }
+
+    for name, info in accounts.items():
+        account_errors = []
+        for key, placeholder in placeholders.items():
+            val = info.get(key)
+            if not val:
+                account_errors.append(f"missing {key}")
+            elif val == placeholder:
+                account_errors.append(f"{key} looks like a placeholder")
+
+        if account_errors:
+            errors[name] = "; ".join(account_errors)
+    return errors
+
+
+def load_accounts(config: Dict, account_errors: Dict[str, str]):
+    """Return credentials for configured Note accounts."""
+    accounts = {}
+    cfg_accounts = config.get("note", {}).get("accounts", {})
+    for name, info in cfg_accounts.items():
+        if name in account_errors:
+            continue
+        accounts[name] = info
+    return accounts
+
+
+def _temp_file_from_b64(data: str, suffix: str = "") -> str:
+    """Write base64 data to a temporary file and return its path."""
+    raw = base64.b64decode(data)
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+    tmp.write(raw)
+    tmp.close()
+    return tmp.name
+
+
+def post_to_note(
+    account: str,
+    text: str,
+    media: List[str],
+    thumbnail: str,
+    paid: bool,
+    tags: List[str],
+    *,
+    accounts: Dict[str, Dict[str, str]],
+    account_errors: Dict[str, str],
+) -> Dict[str, Any]:
+    """Automate posting to note.com using Selenium."""
+
+    print(f"[NOTE] Starting post for account: {account}")
+
+    if account in account_errors:
+        return {"error": "Account misconfigured"}
+
+    creds = accounts.get(account)
+    if not creds:
+        return {"error": "Account not configured"}
+
+    options = ChromeOptions()
+    if HEADLESS:
+        options.add_argument("--headless")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    print("[NOTE] Launching Chrome")
+    driver = webdriver.Chrome(options=options)
+
+    def _capture_screenshot():
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+        tmp.close()
+        try:
+            driver.save_screenshot(tmp.name)
+        except Exception as exc:
+            print(f"[NOTE] Failed to save screenshot: {exc}")
+        return tmp.name
+
+    def _fail_step(step: str, exc: Exception):
+        path = _capture_screenshot()
+        msg = f"{step} failed: {exc}"
+        print(f"[NOTE] {msg}; screenshot {path}")
+        return {"error": msg, "screenshot": path}
+
+    def _send_to_new_input(input_selector: str, path: str, trigger: Optional[Any] = None):
+        if trigger is not None:
+            trigger.click()
+        WebDriverWait(driver, 20).until(
+            lambda d: len(d.find_elements(By.CSS_SELECTOR, input_selector)) > 0
+        )
+        inputs = driver.find_elements(By.CSS_SELECTOR, input_selector)
+        inputs[-1].send_keys(path)
+
+    try:
+        wait = WebDriverWait(driver, 20)
+
+        # --- Login step ---
+        try:
+            login_url = NOTE_SELECTORS["login_url"] + urllib.parse.quote(
+                NOTE_SELECTORS["home_url"]
+            )
+            login_base = NOTE_SELECTORS["login_url"].split("?")[0]
+            driver.get(login_url)
+            wait.until(
+                EC.presence_of_element_located(
+                    (By.CSS_SELECTOR, NOTE_SELECTORS["login_username"])
+                )
+            )
+            username_field = driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_username"])
+            username_field.clear()
+            username_field.send_keys(creds["username"])
+            password_field = driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_password"])
+            password_field.clear()
+            password_field.send_keys(creds["password"])
+
+            wait.until(
+                lambda d: d.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_submit"]).is_enabled()
+            )
+            login_button = driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_submit"])
+            login_button.click()
+            login_button.click()
+            wait.until(lambda d: not d.current_url.startswith(login_base))
+            print("[NOTE] Logged in")
+        except Exception as exc:
+            return _fail_step("login", exc)
+
+        # --- Open new post page ---
+        try:
+            driver.get(NOTE_SELECTORS["home_url"])
+            wait.until(
+                EC.element_to_be_clickable((By.XPATH, NOTE_SELECTORS["post_menu"]))
+            )
+            driver.find_element(By.XPATH, NOTE_SELECTORS["post_menu"]).click()
+            wait.until(
+                EC.element_to_be_clickable((By.XPATH, NOTE_SELECTORS["new_post_menu"]))
+            )
+            driver.find_element(By.XPATH, NOTE_SELECTORS["new_post_menu"]).click()
+            wait.until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, NOTE_SELECTORS["editor_title"]))
+            )
+            print("[NOTE] Editor opened")
+        except Exception as exc:
+            return _fail_step("open new post", exc)
+
+        # --- Compose content / upload media ---
+        try:
+            title_text = text.splitlines()[0][:20] if text else ""
+            driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["title_area"]).send_keys(title_text)
+            print("[NOTE] Title entered")
+        except Exception as exc:
+            return _fail_step("enter title", exc)
+
+        try:
+            body = driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["text_area"])
+            body.send_keys(text)
+            print("[NOTE] Body entered")
+        except Exception as exc:
+            return _fail_step("enter body", exc)
+
+        for item in media:
+            try:
+                print("[NOTE] Uploading media item")
+                path_f = _temp_file_from_b64(item)
+                buttons = driver.find_elements(By.XPATH, NOTE_SELECTORS["media_button"])
+                if not buttons:
+                    raise Exception("media button not found")
+                button = buttons[0]
+                _send_to_new_input(NOTE_SELECTORS["media_input"], path_f, button)
+                print("[NOTE] Media item uploaded")
+            except Exception as exc:
+                return _fail_step("upload media", exc)
+            finally:
+                os.unlink(path_f)
+
+        if thumbnail:
+            try:
+                print("[NOTE] Uploading thumbnail")
+                path_f = _temp_file_from_b64(thumbnail)
+                buttons = driver.find_elements(By.XPATH, NOTE_SELECTORS["thumbnail_button"])
+                if not buttons:
+                    raise Exception("thumbnail button not found")
+                button = buttons[0]
+                _send_to_new_input(NOTE_SELECTORS["thumbnail_input"], path_f, button)
+                print("[NOTE] Thumbnail uploaded")
+            except Exception as exc:
+                return _fail_step("upload thumbnail", exc)
+            finally:
+                os.unlink(path_f)
+
+        try:
+            if paid:
+                driver.find_element(By.XPATH, NOTE_SELECTORS["paid_tab"]).click()
+            else:
+                driver.find_element(By.XPATH, NOTE_SELECTORS["free_tab"]).click()
+            print("[NOTE] Paid/free option set")
+        except Exception as exc:
+            return _fail_step("set paid/free", exc)
+
+        for tag in tags:
+            try:
+                tag_field = driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["tag_input"])
+                tag_field.send_keys(tag)
+                tag_field.send_keys(Keys.ENTER)
+                print(f"[NOTE] Tag added: {tag}")
+            except Exception as exc:
+                return _fail_step("add tag", exc)
+
+        # --- Publish step ---
+        try:
+            wait.until(
+                EC.element_to_be_clickable((By.XPATH, NOTE_SELECTORS["publish_next"]))
+            )
+            driver.find_element(By.XPATH, NOTE_SELECTORS["publish_next"]).click()
+            print("[NOTE] Proceeding to publish")
+            wait.until(
+                EC.element_to_be_clickable((By.XPATH, NOTE_SELECTORS["publish"]))
+            )
+            driver.find_element(By.XPATH, NOTE_SELECTORS["publish"]).click()
+            print("[NOTE] Publish button clicked")
+            wait.until(EC.url_contains("/notes/"))
+            print("[NOTE] Post published")
+            return {"posted": True}
+        except Exception as exc:
+            return _fail_step("publish", exc)
+    finally:
+        print("[NOTE] Closing browser")
+        driver.quit()

--- a/server.py
+++ b/server.py
@@ -1,24 +1,13 @@
 import json
 from pathlib import Path
-from typing import List, Optional, Dict, Any
-
-import os
-import tempfile
-
-import base64
-from io import BytesIO
-from mastodon import Mastodon
-import tweepy
-from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.chrome.options import Options as ChromeOptions
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-import urllib.parse
+from typing import List, Optional, Dict
 
 from fastapi import FastAPI
 from pydantic import BaseModel
+
+import mastodon_service
+import twitter_service
+import note_service
 
 CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
 
@@ -31,233 +20,54 @@ else:
 
 app = FastAPI(title="autoPoster")
 
-# By default Selenium runs in headless mode.  When the server is started with
-# the --show-browser flag this global is set to False so a visible browser is
-# launched instead.
-HEADLESS = True
-
-
-def validate_mastodon_accounts(config: Dict) -> Dict[str, str]:
-    """Validate Mastodon account configuration and return a map of errors."""
-    errors: Dict[str, str] = {}
-    accounts = config.get("mastodon", {}).get("accounts")
-    if not accounts:
-        errors["_general"] = "mastodon.accounts section missing or empty"
-        return errors
-
-    for name, info in accounts.items():
-        account_errors = []
-        instance = info.get("instance_url")
-        token = info.get("access_token")
-
-        if not instance:
-            account_errors.append("missing instance_url")
-        elif "mastodon.example" in instance:
-            account_errors.append("instance_url looks like a placeholder")
-
-        if not token:
-            account_errors.append("missing access_token")
-        elif token == "YOUR_TOKEN":
-            account_errors.append("access_token looks like a placeholder")
-
-        if account_errors:
-            errors[name] = "; ".join(account_errors)
-    return errors
-
-
-MASTODON_ACCOUNT_ERRORS = validate_mastodon_accounts(CONFIG)
+# --- Mastodon setup ---
+MASTODON_ACCOUNT_ERRORS = mastodon_service.validate_accounts(CONFIG)
 if MASTODON_ACCOUNT_ERRORS:
     for acc, err in MASTODON_ACCOUNT_ERRORS.items():
         print(f"Mastodon config error for {acc}: {err}")
+MASTODON_CLIENTS = mastodon_service.create_clients(CONFIG, MASTODON_ACCOUNT_ERRORS)
 
-
-def create_mastodon_clients():
-    """Create Mastodon clients for all configured accounts."""
-    clients = {}
-    accounts = CONFIG.get("mastodon", {}).get("accounts", {})
-    for name, info in accounts.items():
-        if name in MASTODON_ACCOUNT_ERRORS:
-            continue
-        try:
-            clients[name] = Mastodon(
-                access_token=info["access_token"],
-                api_base_url=info["instance_url"],
-            )
-        except Exception as exc:
-            # Log error but continue creating other clients
-            print(f"Failed to init Mastodon client for {name}: {exc}")
-    return clients
-
-
-MASTODON_CLIENTS = create_mastodon_clients()
-
-
-def validate_note_accounts(config: Dict) -> Dict[str, str]:
-    """Validate Note account configuration and return a map of errors."""
-    errors: Dict[str, str] = {}
-    accounts = config.get("note", {}).get("accounts")
-    if not accounts:
-        errors["_general"] = "note.accounts section missing or empty"
-        return errors
-
-    placeholders = {
-        "username": "your_username",
-        "password": "your_password",
-    }
-
-    for name, info in accounts.items():
-        account_errors = []
-        for key, placeholder in placeholders.items():
-            val = info.get(key)
-            if not val:
-                account_errors.append(f"missing {key}")
-            elif val == placeholder:
-                account_errors.append(f"{key} looks like a placeholder")
-
-        if account_errors:
-            errors[name] = "; ".join(account_errors)
-    return errors
-
-
-NOTE_ACCOUNT_ERRORS = validate_note_accounts(CONFIG)
-if NOTE_ACCOUNT_ERRORS:
-    for acc, err in NOTE_ACCOUNT_ERRORS.items():
-        print(f"Note config error for {acc}: {err}")
-
-
-def load_note_accounts():
-    """Return credentials for configured Note accounts."""
-    accounts = {}
-    cfg_accounts = CONFIG.get("note", {}).get("accounts", {})
-    for name, info in cfg_accounts.items():
-        if name in NOTE_ACCOUNT_ERRORS:
-            continue
-        accounts[name] = info
-    return accounts
-
-
-NOTE_ACCOUNTS = load_note_accounts()
-
-# CSS selectors and URLs used to automate posting to Note
-NOTE_SELECTORS = {
-    "login_url": "https://note.com/login?redirectPath=",
-    "login_username": "#email",
-    "login_password": "#password",
-    "login_submit": ".o-login__button button",
-    # After login we navigate to the home page then open the editor via the
-    # 「投稿」 button. The old ``/notes/new`` URL no longer works directly.
-    "home_url": "https://note.com/",
-    # Home screen "投稿" element became a <button>. Search for either <button>
-    # or <a> to be robust across UI changes.
-    "post_menu": "//*[self::button or self::a][contains(., '投稿')]",
-    # "新しく記事を書く" now appears as an <a> element but may revert to a
-    # button in future. Match either tag and also fall back to the /notes/new
-    # href to be more robust.
-    "new_post_menu": (
-        "//*[self::button or self::a][contains(., '新しく記事を書く')" 
-        " or contains(@href, '/notes/new')]"
-    ),
-
-    # Editor fields use either a textarea or a contenteditable DIV depending on
-    # the current Note UI. The title element also acts as a marker that the
-    # editor page has finished loading.
-    "editor_title": "textarea[placeholder='記事タイトル'], div[data-placeholder='記事タイトル']",
-    # Title input area
-    "title_area": "textarea[placeholder='記事タイトル'], div[data-placeholder='記事タイトル']",
-    # Use a generic selector for the body area as the placeholder text can
-    # change over time. The role attribute is stable across revisions.
-    "text_area": "div[contenteditable='true'][role='textbox']",
-
-    # File inputs appear after clicking their respective UI controls.
-    "media_input": "input[type='file']",
-    # Body image uploads are triggered via a menu where the "画像" option is
-    # shown. Match either visible text or an aria-label containing "画像" so the
-    # selector keeps working if the surrounding UI changes.
-    "media_button": "//button[contains(@aria-label, '画像') or contains(., '画像')]",
-    "thumbnail_button": (
-        "//button[contains(@aria-label, '画像をアップロード') or "
-        "contains(., '画像をアップロード')]"
-    ),
-    "thumbnail_input": "input[type='file']",
-
-    # Paid/free toggle became radio-style labels.
-    "paid_tab": "//label[contains(., '有料')]/input",
-    "free_tab": "//label[contains(., '無料')]/input",
-
-    # Tags now use a placeholder attribute.
-    "tag_input": "input[placeholder='ハッシュタグを追加する']",
-
-    # Publishing now requires two buttons: "公開に進む" then "投稿する"/"更新する".
-    "publish_next": "//button[contains(., '公開に進む')]",
-    "publish": "//button[contains(., '投稿する') or contains(., '更新する')]",
-}
-
-
-def validate_twitter_accounts(config: Dict) -> Dict[str, str]:
-    """Validate Twitter account configuration and return a map of errors."""
-    errors: Dict[str, str] = {}
-    accounts = config.get("twitter", {}).get("accounts")
-    if not accounts:
-        errors["_general"] = "twitter.accounts section missing or empty"
-        return errors
-
-    placeholders = {
-        "consumer_key": "YOUR_CONSUMER_KEY",
-        "consumer_secret": "YOUR_CONSUMER_SECRET",
-        "access_token": "YOUR_ACCESS_TOKEN",
-        "access_token_secret": "YOUR_ACCESS_TOKEN_SECRET",
-        "bearer_token": "YOUR_BEARER_TOKEN",
-    }
-
-    for name, info in accounts.items():
-        account_errors = []
-        for key in placeholders:
-            val = info.get(key)
-            if not val:
-                account_errors.append(f"missing {key}")
-            elif val == placeholders[key]:
-                account_errors.append(f"{key} looks like a placeholder")
-
-        if account_errors:
-            errors[name] = "; ".join(account_errors)
-    return errors
-
-
-TWITTER_ACCOUNT_ERRORS = validate_twitter_accounts(CONFIG)
+# --- Twitter setup ---
+TWITTER_ACCOUNT_ERRORS = twitter_service.validate_accounts(CONFIG)
 if TWITTER_ACCOUNT_ERRORS:
     for acc, err in TWITTER_ACCOUNT_ERRORS.items():
         print(f"Twitter config error for {acc}: {err}")
+TWITTER_CLIENTS = twitter_service.create_clients(CONFIG, TWITTER_ACCOUNT_ERRORS)
+
+# --- Note setup ---
+NOTE_ACCOUNT_ERRORS = note_service.validate_accounts(CONFIG)
+if NOTE_ACCOUNT_ERRORS:
+    for acc, err in NOTE_ACCOUNT_ERRORS.items():
+        print(f"Note config error for {acc}: {err}")
+NOTE_ACCOUNTS = note_service.load_accounts(CONFIG, NOTE_ACCOUNT_ERRORS)
+
+# Expose selectors for tests
+NOTE_SELECTORS = note_service.NOTE_SELECTORS
+
+
+def validate_mastodon_accounts(config: Dict) -> Dict[str, str]:
+    return mastodon_service.validate_accounts(config)
+
+
+def create_mastodon_clients():
+    return mastodon_service.create_clients(CONFIG, MASTODON_ACCOUNT_ERRORS)
+
+
+def validate_twitter_accounts(config: Dict) -> Dict[str, str]:
+    return twitter_service.validate_accounts(config)
 
 
 def create_twitter_clients():
-    """Create Tweepy clients for all configured accounts."""
-    clients = {}
-    accounts = CONFIG.get("twitter", {}).get("accounts", {})
-    for name, info in accounts.items():
-        if name in TWITTER_ACCOUNT_ERRORS:
-            continue
-        try:
-            auth = tweepy.OAuth1UserHandler(
-                info["consumer_key"],
-                info["consumer_secret"],
-                info["access_token"],
-                info["access_token_secret"],
-            )
-            api = tweepy.API(auth)
-            client = tweepy.Client(
-                bearer_token=info["bearer_token"],
-                consumer_key=info["consumer_key"],
-                consumer_secret=info["consumer_secret"],
-                access_token=info["access_token"],
-                access_token_secret=info["access_token_secret"],
-            )
-            clients[name] = {"client": client, "api": api}
-        except Exception as exc:
-            print(f"Failed to init Twitter client for {name}: {exc}")
-    return clients
+    return twitter_service.create_clients(CONFIG, TWITTER_ACCOUNT_ERRORS)
 
 
-TWITTER_CLIENTS = create_twitter_clients()
+def validate_note_accounts(config: Dict) -> Dict[str, str]:
+    return note_service.validate_accounts(config)
+
+
+def load_note_accounts():
+    return note_service.load_accounts(CONFIG, NOTE_ACCOUNT_ERRORS)
+
 
 class PostRequest(BaseModel):
     text: str
@@ -285,75 +95,26 @@ class NotePostRequest(BaseModel):
     tags: Optional[List[str]] = None
 
 
+# Wrapper functions -----------------------------------------------------------
+
 def post_to_mastodon(account: str, text: str, media: Optional[List[str]] = None):
-    if account in MASTODON_ACCOUNT_ERRORS:
-        return {"error": "Account misconfigured"}
-    client = MASTODON_CLIENTS.get(account)
-    if not client:
-        return {"error": "Account not configured"}
-
-    media_ids = None
-    if media:
-        media_ids = []
-        for item in media:
-            try:
-                data = base64.b64decode(item)
-                uploaded = client.media_post(BytesIO(data), mime_type="application/octet-stream")
-                media_ids.append(uploaded.get("id"))
-            except Exception as exc:
-                return {"error": f"Media upload failed: {exc}"}
-
-    try:
-        client.status_post(text, media_ids=media_ids)
-    except Exception as exc:
-        return {"error": str(exc)}
-
-    return {"posted": True}
+    return mastodon_service.post_to_mastodon(
+        account,
+        text,
+        media,
+        clients=MASTODON_CLIENTS,
+        account_errors=MASTODON_ACCOUNT_ERRORS,
+    )
 
 
 def post_to_twitter(account: str, text: str, media: Optional[List[str]] = None):
-    if account in TWITTER_ACCOUNT_ERRORS:
-        return {"error": "Account misconfigured"}
-    info = TWITTER_CLIENTS.get(account)
-    if not info:
-        return {"error": "Account not configured"}
-
-    client = info["client"]
-    api = info["api"]
-
-    media_ids = None
-    if media:
-        media_ids = []
-        for item in media:
-            try:
-                data = base64.b64decode(item)
-                uploaded = api.media_upload(filename="media", file=BytesIO(data))
-                media_ids.append(uploaded.media_id)
-            except Exception as exc:
-                return {"error": f"Media upload failed: {exc}"}
-
-    try:
-        client.create_tweet(text=text, media_ids=media_ids)
-    except Exception as exc:
-        return {"error": str(exc)}
-
-    return {"posted": True}
-
-
-def _temp_file_from_b64(data: str, suffix: str = "") -> str:
-    """Write base64 data to a temporary file and return its path."""
-    try:
-        raw = base64.b64decode(data)
-    except Exception as exc:
-        if not HEADLESS:
-            print(f"[DEBUG] base64 decode failed: {exc}")
-        raise
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
-    tmp.write(raw)
-    tmp.close()
-    if not HEADLESS:
-        print(f"[DEBUG] wrote {len(raw)} bytes to {tmp.name}")
-    return tmp.name
+    return twitter_service.post_to_twitter(
+        account,
+        text,
+        media,
+        clients=TWITTER_CLIENTS,
+        account_errors=TWITTER_ACCOUNT_ERRORS,
+    )
 
 
 def post_to_note(
@@ -364,229 +125,27 @@ def post_to_note(
     paid: bool,
     tags: List[str],
 ):
-    """Automate posting to note.com using Selenium."""
+    return note_service.post_to_note(
+        account,
+        text,
+        media,
+        thumbnail,
+        paid,
+        tags,
+        accounts=NOTE_ACCOUNTS,
+        account_errors=NOTE_ACCOUNT_ERRORS,
+    )
 
-    # Debug: announce which account we're using
-    print(f"[NOTE] Starting post for account: {account}")
 
-    if account in NOTE_ACCOUNT_ERRORS:
-        return {"error": "Account misconfigured"}
-
-    creds = NOTE_ACCOUNTS.get(account)
-    if not creds:
-        return {"error": "Account not configured"}
-
-    options = ChromeOptions()
-    if HEADLESS:
-        options.add_argument("--headless")
-    options.add_argument("--no-sandbox")
-    options.add_argument("--disable-dev-shm-usage")
-    print("[NOTE] Launching Chrome")
-    driver = webdriver.Chrome(options=options)
-
-    def _capture_screenshot():
-        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
-        tmp.close()
-        try:
-            driver.save_screenshot(tmp.name)
-        except Exception as exc:
-            print(f"[NOTE] Failed to save screenshot: {exc}")
-        return tmp.name
-
-    def _fail_step(step: str, exc: Exception):
-        """Log step failure with screenshot and return error response."""
-        path = _capture_screenshot()
-        msg = f"{step} failed: {exc}"
-        print(f"[NOTE] {msg}; screenshot {path}")
-        return {"error": msg, "screenshot": path}
-
-    def _send_to_new_input(input_selector: str, path: str, trigger: Optional[Any] = None):
-        """Click the trigger and send the file path to the last file input."""
-        if trigger is not None:
-            if not HEADLESS:
-                print("[DEBUG] clicking trigger for input")
-            trigger.click()
-        if not HEADLESS:
-            print("[DEBUG] waiting for input element")
-        wait.until(lambda d: len(d.find_elements(By.CSS_SELECTOR, input_selector)) > 0)
-        inputs = driver.find_elements(By.CSS_SELECTOR, input_selector)
-        if not HEADLESS:
-            print(f"[DEBUG] input elements found: {len(inputs)}")
-        inputs[-1].send_keys(path)
-
-    try:
-        wait = WebDriverWait(driver, 20)
-
-        # --- Login step ---
-        try:
-            # Load the login page directly with a redirectPath parameter so the form shows
-            login_url = NOTE_SELECTORS["login_url"] + urllib.parse.quote(
-                NOTE_SELECTORS["home_url"]
-            )
-            login_base = NOTE_SELECTORS["login_url"].split("?")[0]
-            driver.get(login_url)
-            # Wait for the login form fields to appear
-            wait.until(
-                EC.presence_of_element_located(
-                    (By.CSS_SELECTOR, NOTE_SELECTORS["login_username"])
-                )
-            )
-            username_field = driver.find_element(
-                By.CSS_SELECTOR, NOTE_SELECTORS["login_username"]
-            )
-            username_field.clear()
-            username_field.send_keys(creds["username"])
-            password_field = driver.find_element(
-                By.CSS_SELECTOR, NOTE_SELECTORS["login_password"]
-            )
-            password_field.clear()
-            password_field.send_keys(creds["password"])
-
-            # Wait until the login button becomes enabled before clicking
-            wait.until(
-                lambda d: d.find_element(
-                    By.CSS_SELECTOR, NOTE_SELECTORS["login_submit"]
-                ).is_enabled()
-            )
-            login_button = driver.find_element(
-                By.CSS_SELECTOR, NOTE_SELECTORS["login_submit"]
-            )
-            login_button.click()
-            # Sometimes the first click is missed; send a second one
-            login_button.click()
-            wait.until(lambda d: not d.current_url.startswith(login_base))
-            print("[NOTE] Logged in")
-        except Exception as exc:
-            return _fail_step("login", exc)
-
-        # --- Open new post page ---
-        try:
-            driver.get(NOTE_SELECTORS["home_url"])
-            wait.until(
-                EC.element_to_be_clickable((By.XPATH, NOTE_SELECTORS["post_menu"]))
-            )
-            driver.find_element(By.XPATH, NOTE_SELECTORS["post_menu"]).click()
-            wait.until(
-                EC.element_to_be_clickable((By.XPATH, NOTE_SELECTORS["new_post_menu"]))
-            )
-            driver.find_element(By.XPATH, NOTE_SELECTORS["new_post_menu"]).click()
-            # Wait until the editor page loads by checking the title element
-            wait.until(
-                EC.presence_of_element_located((By.CSS_SELECTOR, NOTE_SELECTORS["editor_title"]))
-            )
-            print("[NOTE] Editor opened")
-        except Exception as exc:
-            return _fail_step("open new post", exc)
-
-        # --- Compose content / upload media ---
-        try:
-            title_text = text.splitlines()[0][:20] if text else ""
-            driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["title_area"]).send_keys(title_text)
-            print("[NOTE] Title entered")
-        except Exception as exc:
-            return _fail_step("enter title", exc)
-
-        try:
-            body = driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["text_area"])
-            body.send_keys(text)
-            print("[NOTE] Body entered")
-        except Exception as exc:
-            return _fail_step("enter body", exc)
-
-        for item in media:
-            try:
-                print("[NOTE] Uploading media item")
-                path_f = _temp_file_from_b64(item)
-                if not HEADLESS:
-                    exists = os.path.exists(path_f)
-                    print(f"[DEBUG] temp file {path_f} exists={exists}")
-                buttons = driver.find_elements(By.XPATH, NOTE_SELECTORS["media_button"])
-                if not HEADLESS:
-                    print(f"[DEBUG] media_button elements found: {len(buttons)}")
-                if not buttons:
-                    raise Exception("media button not found")
-                button = buttons[0]
-                _send_to_new_input(NOTE_SELECTORS["media_input"], path_f, button)
-                if not HEADLESS:
-                    sc_path = _capture_screenshot()
-                    print(f"[DEBUG] screenshot after upload attempt: {sc_path}")
-                print("[NOTE] Media item uploaded")
-            except Exception as exc:
-                return _fail_step("upload media", exc)
-            finally:
-                os.unlink(path_f)
-
-        if thumbnail:
-            try:
-                print("[NOTE] Uploading thumbnail")
-                path_f = _temp_file_from_b64(thumbnail)
-                if not HEADLESS:
-                    exists = os.path.exists(path_f)
-                    print(f"[DEBUG] thumbnail temp {path_f} exists={exists}")
-                buttons = driver.find_elements(By.XPATH, NOTE_SELECTORS["thumbnail_button"])
-                if not HEADLESS:
-                    print(f"[DEBUG] thumbnail_button elements found: {len(buttons)}")
-                if not buttons:
-                    raise Exception("thumbnail button not found")
-                button = buttons[0]
-                _send_to_new_input(NOTE_SELECTORS["thumbnail_input"], path_f, button)
-                if not HEADLESS:
-                    sc_path = _capture_screenshot()
-                    print(f"[DEBUG] screenshot after thumbnail upload: {sc_path}")
-                print("[NOTE] Thumbnail uploaded")
-            except Exception as exc:
-                return _fail_step("upload thumbnail", exc)
-            finally:
-                os.unlink(path_f)
-
-        try:
-            if paid:
-                driver.find_element(By.XPATH, NOTE_SELECTORS["paid_tab"]).click()
-            else:
-                driver.find_element(By.XPATH, NOTE_SELECTORS["free_tab"]).click()
-            print("[NOTE] Paid/free option set")
-        except Exception as exc:
-            return _fail_step("set paid/free", exc)
-
-        for tag in tags:
-            try:
-                tag_field = driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["tag_input"])
-                tag_field.send_keys(tag)
-                tag_field.send_keys(Keys.ENTER)
-                print(f"[NOTE] Tag added: {tag}")
-            except Exception as exc:
-                return _fail_step("add tag", exc)
-
-        # --- Publish step ---
-        try:
-            wait.until(
-                EC.element_to_be_clickable(
-                    (By.XPATH, NOTE_SELECTORS["publish_next"])
-                )
-            )
-            driver.find_element(By.XPATH, NOTE_SELECTORS["publish_next"]).click()
-            print("[NOTE] Proceeding to publish")
-            wait.until(
-                EC.element_to_be_clickable((By.XPATH, NOTE_SELECTORS["publish"]))
-            )
-            driver.find_element(By.XPATH, NOTE_SELECTORS["publish"]).click()
-            print("[NOTE] Publish button clicked")
-            wait.until(EC.url_contains("/notes/"))
-            print("[NOTE] Post published")
-            return {"posted": True}
-        except Exception as exc:
-            return _fail_step("publish", exc)
-    finally:
-        print("[NOTE] Closing browser")
-        driver.quit()
+# API Routes -----------------------------------------------------------------
 
 @app.get("/")
 async def root():
     return {"status": "ok"}
 
+
 @app.post("/post")
 async def receive_post(data: PostRequest):
-    # For now just log that data was received
     media_count = len(data.media or [])
     return {"received": True, "media_items": media_count}
 
@@ -612,6 +171,7 @@ async def note_post(data: NotePostRequest):
         data.tags or [],
     )
 
+
 if __name__ == "__main__":
     import argparse
     import uvicorn
@@ -625,6 +185,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.show_browser:
-        HEADLESS = False
+        note_service.HEADLESS = False
 
     uvicorn.run(app, host="127.0.0.1", port=8765)

--- a/test_mastodon_post.py
+++ b/test_mastodon_post.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 import server
+import mastodon_service
 
 class DummyMastodon:
     def __init__(self, *args, **kwargs):
@@ -61,7 +62,7 @@ def make_client(monkeypatch, config=None, mastodon_cls=None):
     if config is not None:
         monkeypatch.setattr(server, 'CONFIG', config, raising=False)
     if mastodon_cls:
-        monkeypatch.setattr(server, 'Mastodon', mastodon_cls)
+        monkeypatch.setattr(mastodon_service, 'Mastodon', mastodon_cls)
     server.MASTODON_ACCOUNT_ERRORS = server.validate_mastodon_accounts(server.CONFIG)
     server.MASTODON_CLIENTS = server.create_mastodon_clients()
     return TestClient(server.app)

--- a/test_note_post_route.py
+++ b/test_note_post_route.py
@@ -1,5 +1,6 @@
 import json
 import server
+import note_service
 from fastapi.testclient import TestClient
 import pytest
 
@@ -82,14 +83,14 @@ def make_client(monkeypatch, config=None):
 
 
 def patch_driver(monkeypatch, fail_selector=None):
-    monkeypatch.setattr(server.webdriver, 'Chrome', lambda *a, **kw: DummyDriver(fail_selector))
-    monkeypatch.setattr(server, 'WebDriverWait', lambda driver, timeout: DummyWait(driver, timeout))
+    monkeypatch.setattr(note_service.webdriver, 'Chrome', lambda *a, **kw: DummyDriver(fail_selector))
+    monkeypatch.setattr(note_service, 'WebDriverWait', lambda driver, timeout: DummyWait(driver, timeout))
     import tempfile
     def fake_temp(data, suffix=''):
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
         tmp.close()
         return tmp.name
-    monkeypatch.setattr(server, '_temp_file_from_b64', fake_temp)
+    monkeypatch.setattr(note_service, '_temp_file_from_b64', fake_temp)
 
 
 def test_note_post_success(monkeypatch, note_temp_config):
@@ -129,7 +130,7 @@ def test_note_post_misconfigured(monkeypatch, note_config_writer):
 
 
 def test_note_post_login_error(monkeypatch, note_temp_config):
-    fail = server.NOTE_SELECTORS['login_username']
+    fail = note_service.NOTE_SELECTORS['login_username']
     patch_driver(monkeypatch, fail_selector=fail)
     client = make_client(monkeypatch)
     payload = {'account': 'acc', 'text': 'x', 'paid': False}
@@ -141,7 +142,7 @@ def test_note_post_login_error(monkeypatch, note_temp_config):
 
 
 def test_note_post_publish_error(monkeypatch, note_temp_config):
-    fail = server.NOTE_SELECTORS['publish']
+    fail = note_service.NOTE_SELECTORS['publish']
     patch_driver(monkeypatch, fail_selector=fail)
     client = make_client(monkeypatch)
     payload = {'account': 'acc', 'text': 'x', 'paid': False}

--- a/test_twitter_post.py
+++ b/test_twitter_post.py
@@ -6,6 +6,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 import server
+import twitter_service
+import twitter_service
 
 
 class DummyAPI:
@@ -69,10 +71,10 @@ def make_client(monkeypatch, config=None, client_cls=None, api_cls=None):
     if config is not None:
         monkeypatch.setattr(server, 'CONFIG', config, raising=False)
     if client_cls:
-        monkeypatch.setattr(server.tweepy, 'Client', client_cls)
+        monkeypatch.setattr(twitter_service.tweepy, 'Client', client_cls)
     if api_cls:
-        monkeypatch.setattr(server.tweepy, 'API', api_cls)
-    monkeypatch.setattr(server.tweepy, 'OAuth1UserHandler', lambda *a, **kw: None)
+        monkeypatch.setattr(twitter_service.tweepy, 'API', api_cls)
+    monkeypatch.setattr(twitter_service.tweepy, 'OAuth1UserHandler', lambda *a, **kw: None)
     server.TWITTER_ACCOUNT_ERRORS = server.validate_twitter_accounts(server.CONFIG)
     server.TWITTER_CLIENTS = server.create_twitter_clients()
     return TestClient(server.app)

--- a/twitter_service.py
+++ b/twitter_service.py
@@ -1,0 +1,100 @@
+import base64
+from io import BytesIO
+from typing import Dict, List, Optional
+
+import tweepy
+
+
+def validate_accounts(config: Dict) -> Dict[str, str]:
+    """Validate Twitter account configuration and return a map of errors."""
+    errors: Dict[str, str] = {}
+    accounts = config.get("twitter", {}).get("accounts")
+    if not accounts:
+        errors["_general"] = "twitter.accounts section missing or empty"
+        return errors
+
+    placeholders = {
+        "consumer_key": "YOUR_CONSUMER_KEY",
+        "consumer_secret": "YOUR_CONSUMER_SECRET",
+        "access_token": "YOUR_ACCESS_TOKEN",
+        "access_token_secret": "YOUR_ACCESS_TOKEN_SECRET",
+        "bearer_token": "YOUR_BEARER_TOKEN",
+    }
+
+    for name, info in accounts.items():
+        account_errors = []
+        for key in placeholders:
+            val = info.get(key)
+            if not val:
+                account_errors.append(f"missing {key}")
+            elif val == placeholders[key]:
+                account_errors.append(f"{key} looks like a placeholder")
+
+        if account_errors:
+            errors[name] = "; ".join(account_errors)
+    return errors
+
+
+def create_clients(config: Dict, account_errors: Dict[str, str]):
+    """Create Tweepy clients for all configured accounts."""
+    clients = {}
+    accounts = config.get("twitter", {}).get("accounts", {})
+    for name, info in accounts.items():
+        if name in account_errors:
+            continue
+        try:
+            auth = tweepy.OAuth1UserHandler(
+                info["consumer_key"],
+                info["consumer_secret"],
+                info["access_token"],
+                info["access_token_secret"],
+            )
+            api = tweepy.API(auth)
+            client = tweepy.Client(
+                bearer_token=info["bearer_token"],
+                consumer_key=info["consumer_key"],
+                consumer_secret=info["consumer_secret"],
+                access_token=info["access_token"],
+                access_token_secret=info["access_token_secret"],
+            )
+            clients[name] = {"client": client, "api": api}
+        except Exception as exc:
+            print(f"Failed to init Twitter client for {name}: {exc}")
+    return clients
+
+
+def post_to_twitter(
+    account: str,
+    text: str,
+    media: Optional[List[str]] = None,
+    *,
+    clients: Dict[str, Dict[str, any]],
+    account_errors: Dict[str, str],
+):
+    """Send a tweet with optional media."""
+    if account in account_errors:
+        return {"error": "Account misconfigured"}
+    info = clients.get(account)
+    if not info:
+        return {"error": "Account not configured"}
+
+    client = info["client"]
+    api = info["api"]
+
+    media_ids = None
+    if media:
+        media_ids = []
+        for item in media:
+            try:
+                data = base64.b64decode(item)
+                uploaded = api.media_upload(filename="media", file=BytesIO(data))
+                media_ids.append(uploaded.media_id)
+            except Exception as exc:
+                return {"error": f"Media upload failed: {exc}"}
+
+    try:
+        client.create_tweet(text=text, media_ids=media_ids)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+    return {"posted": True}


### PR DESCRIPTION
## Summary
- split large `server.py` into dedicated service modules
- keep API endpoints but wrap calls to the new service modules
- adjust tests to patch the new modules

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688893eee9648329976dbe0d712f6e99