### PR TITLE
Fix duplicate login click

### DIFF
--- a/note_service.py
+++ b/note_service.py
@@ -180,7 +180,6 @@ def post_to_note(
             )
             login_button = driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_submit"])
             login_button.click()
-            login_button.click()
             wait.until(lambda d: not d.current_url.startswith(login_base))
             print("[NOTE] Logged in")
         except Exception as exc:


### PR DESCRIPTION
## Summary
- remove the second `login_button.click()` during the Note login step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a0da8490832981b9f5c6097be251