### PR TITLE
Fix login wait in note service

### DIFF
--- a/note_service.py
+++ b/note_service.py
@@ -179,7 +179,11 @@ def post_to_note(
             )
             login_button = driver.find_element(By.CSS_SELECTOR, NOTE_SELECTORS["login_submit"])
             login_button.click()
-            wait.until(lambda d: not d.current_url.startswith(login_base))
+            WebDriverWait(driver, 40).until(
+                EC.presence_of_element_located(
+                    (By.XPATH, NOTE_SELECTORS["post_menu"])
+                )
+            )
             print("[NOTE] Logged in")
         except Exception as exc:
             return _fail_step("login", exc)


### PR DESCRIPTION
## Summary
- wait for home page element after login instead of URL change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b07848e08329b510dca2d7c9f034