### PR TITLE
Log current url for failed Note login

### DIFF
--- a/note_service.py
+++ b/note_service.py
@@ -186,7 +186,8 @@ def post_to_note(
             )
             print("[NOTE] Logged in")
         except Exception as exc:
-            return _fail_step("login", exc)
+            msg = f"{exc} (URL: {driver.current_url})"
+            return _fail_step("login", Exception(msg))
 
         # --- Open new post page ---
         try:

--- a/test_note_post_route.py
+++ b/test_note_post_route.py
@@ -18,8 +18,10 @@ class DummyDriver:
     def __init__(self, fail=None, *args, **kwargs):
         self.fail = fail
         self.actions = []
+        self.current_url = ''
     def get(self, url):
         self.actions.append(('get', url))
+        self.current_url = url
     def find_element(self, by, selector, *args, **kwargs):
         self.actions.append(('find', selector))
         if selector == self.fail:


### PR DESCRIPTION
## Summary
- log the current URL on Note login failure to help trace issues
- update DummyDriver in tests with `current_url`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b30c73148329a0b839c35eba7772