### PR TITLE
Improve debug info on Note input failures

### DIFF
--- a/note_service.py
+++ b/note_service.py
@@ -185,8 +185,17 @@ def post_to_note(
                 finally:
                     driver.switch_to.default_content()
 
+            path_ss = _capture_screenshot()
+            print(f"[DEBUG] screenshot saved: {path_ss}")
+            print(f"[DEBUG] title: {driver.title}")
+            print(f"[DEBUG] url: {driver.current_url}")
+
             raise Exception(f"{exc.__class__.__name__}: {exc}") from exc
         except Exception as exc:
+            path_ss = _capture_screenshot()
+            print(f"[DEBUG] screenshot saved: {path_ss}")
+            print(f"[DEBUG] title: {driver.title}")
+            print(f"[DEBUG] url: {driver.current_url}")
             raise Exception(f"{exc.__class__.__name__}: {exc}") from exc
 
         try:
@@ -219,6 +228,10 @@ def post_to_note(
                 )
             inputs[-1].send_keys(path)
         except Exception as exc:
+            path_ss = _capture_screenshot()
+            print(f"[DEBUG] screenshot saved: {path_ss}")
+            print(f"[DEBUG] title: {driver.title}")
+            print(f"[DEBUG] url: {driver.current_url}")
             raise Exception(f"{exc.__class__.__name__}: {exc}") from exc
 
     try:


### PR DESCRIPTION
## Summary
- capture screenshot within `_send_to_new_input` when errors occur
- print driver title and URL along with screenshot path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688974848f4c8329bc8ecde371060e89