### PR TITLE
Clean up trigger argument

### DIFF
--- a/note_service.py
+++ b/note_service.py
@@ -156,7 +156,6 @@ def post_to_note(
     def _send_to_new_input(
         input_selector: str,
         path: str,
-        trigger: Optional[Any] = None,
         frame_index: Optional[int] = None,
     ):
         # no clicking here


### PR DESCRIPTION
## Summary
- remove unused `trigger` parameter from Note automation helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68898437c07483298930b76938cf86e5