### PR TITLE
Replace absolute paths with placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,22 @@ curl -X POST http://localhost:8765/note/post \
      -d '{"account": "account1", "text": "Another Note", "paid": false, "tags": []}'
 ```
 
+## Example scripts
+
+The repository provides three helper scripts that demonstrate how to send posts
+to each service: `send_mastodon_post.py`, `send_twitter_post.py` and
+`send_note_post.py`.  Each script contains placeholder file paths such as
+`path/to/image.png`.  Replace these strings with the paths to your own media
+files before running the scripts:
+
+```python
+MEDIA_PATH = "path/to/image.png"  # update with your image file
+```
+
+If you wish to post multiple images with Note, edit `MEDIA_PATHS` and
+`THUMBNAIL_PATH` similarly. Paths can be absolute or relative; use whichever is
+convenient on your system.
+
 ## Troubleshooting
 
 If requests to `/mastodon/post` or `/twitter/post` return

--- a/send_mastodon_post.py
+++ b/send_mastodon_post.py
@@ -5,7 +5,7 @@ import requests
 URL = "http://localhost:8765/mastodon/post"
 ACCOUNT = "account1"  # must match an entry in config.json
 TEXT = "これは自動投稿のテストです"
-MEDIA_PATH = "/path/to/image.png"  # replace with an actual file path
+MEDIA_PATH = "path/to/image.png"  # replace with the path to your media file
 
 
 def main():

--- a/send_note_post.py
+++ b/send_note_post.py
@@ -5,8 +5,11 @@ import requests
 URL = "http://localhost:8765/note/post"
 ACCOUNT = "nicchi"  # must match an entry in config.json
 TEXT = "これはテスト投稿です"
-THUMBNAIL_PATH = r"C:\Users\satof\sato\autoPoster\autoPoster\example\titeletest.png"  # replace with an actual file path
-MEDIA_PATHS = [r"C:\Users\satof\sato\autoPoster\autoPoster\example\b6701f05-1e2e-4776-a7c3-69c13c469514.png", r"C:\Users\satof\sato\autoPoster\autoPoster\example\b6701f05-1e2e-4776-a7c3-69c13c46sssss9514.jpg"]  # optional additional images
+THUMBNAIL_PATH = "path/to/thumbnail.png"  # replace with the path to your thumbnail
+MEDIA_PATHS = [
+    "path/to/image1.png",
+    "path/to/image2.jpg",
+]  # optional additional images
 PAID = False
 TAGS = ["test", "ai生成"]
 

--- a/send_twitter_post.py
+++ b/send_twitter_post.py
@@ -5,7 +5,7 @@ import requests
 URL = "http://localhost:8765/twitter/post"
 ACCOUNT = "account1"  # must match an entry in config.json
 TEXT = "これはTwitterへの自動投稿テストです"
-MEDIA_PATH = "/path/to/image.png"  # replace with an actual file path
+MEDIA_PATH = "path/to/image.png"  # replace with the path to your media file
 
 
 def main():


### PR DESCRIPTION
## Summary
- swap hardcoded media paths in helper scripts for placeholder values
- explain in the README how to set paths for helper scripts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68898549002c8329b6ca5c349dc5a0c4