### PR TITLE
Implement NoteClient login functionality

### DIFF
--- a/note_client.py
+++ b/note_client.py
@@ -1,0 +1,25 @@
+import requests
+
+class NoteAuthError(Exception):
+    """Raised when authentication with Note fails."""
+
+
+class NoteClient:
+    """Simple client for Note API."""
+
+    def __init__(self, config: dict, session: requests.Session | None = None):
+        self.config = config or {}
+        self.session = session or requests.Session()
+        note_cfg = self.config.get("note", {})
+        self.base_url = note_cfg.get("base_url", "https://note.com").rstrip("/")
+
+    def login(self) -> None:
+        """Authenticate and store cookies in the session."""
+        note_cfg = self.config.get("note", {})
+        username = note_cfg.get("username")
+        password = note_cfg.get("password")
+        url = f"{self.base_url}/api/v1/sessions/sign_in"
+        resp = self.session.post(url, data={"login": username, "password": password})
+        self.session.cookies.update(resp.cookies)
+        if resp.status_code != 200:
+            raise NoteAuthError(f"Login failed with status {resp.status_code}")

--- a/test_note_client.py
+++ b/test_note_client.py
@@ -1,0 +1,35 @@
+import requests
+import pytest
+from note_client import NoteClient, NoteAuthError
+
+class DummySession:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+        self.post_args = []
+        self.cookies = requests.cookies.RequestsCookieJar()
+
+    def post(self, url, data=None, **kwargs):
+        self.post_args.append((url, data))
+        resp = type('Resp', (), {})()
+        resp.status_code = self.status_code
+        resp.cookies = requests.cookies.RequestsCookieJar()
+        resp.cookies.set('sid', 'cookie')
+        # mimic requests.Session behavior updating cookies
+        self.cookies.update(resp.cookies)
+        return resp
+
+def test_login_success():
+    cfg = {'note': {'username': 'u', 'password': 'p', 'base_url': 'http://host'}}
+    session = DummySession(200)
+    client = NoteClient(cfg, session=session)
+    client.login()
+    assert session.post_args[0][0] == 'http://host/api/v1/sessions/sign_in'
+    assert session.post_args[0][1] == {'login': 'u', 'password': 'p'}
+    assert session.cookies.get('sid') == 'cookie'
+
+def test_login_failure():
+    cfg = {'note': {'username': 'u', 'password': 'p', 'base_url': 'http://host'}}
+    session = DummySession(401)
+    client = NoteClient(cfg, session=session)
+    with pytest.raises(NoteAuthError):
+        client.login()


### PR DESCRIPTION
## Summary
- add `note_client.py` containing the `NoteClient` class and `NoteAuthError`
- `NoteClient.login()` posts to `/api/v1/sessions/sign_in` and stores cookies
- test login success and failure

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b0c05ec2c8329b0d73b7ee7c43459