### PR TITLE
Add NoteClient image upload

### DIFF
--- a/note_client.py
+++ b/note_client.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import requests
 
 class NoteAuthError(Exception):
@@ -23,3 +24,15 @@ class NoteClient:
         self.session.cookies.update(resp.cookies)
         if resp.status_code != 200:
             raise NoteAuthError(f"Login failed with status {resp.status_code}")
+
+    def upload_image(self, path: Path) -> str:
+        """Upload an image and return the CDN URL from the API response."""
+        url = f"{self.base_url}/api/v1/upload_image"
+        try:
+            with path.open("rb") as fh:
+                resp = self.session.post(url, files={"file": fh})
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("url") or data["cdn_url"]
+        except Exception as exc:  # Mimic the simple try/except pattern
+            raise RuntimeError(f"Image upload failed: {exc}") from exc

--- a/test_note_client.py
+++ b/test_note_client.py
@@ -3,17 +3,25 @@ import pytest
 from note_client import NoteClient, NoteAuthError
 
 class DummySession:
-    def __init__(self, status_code=200):
+    def __init__(self, status_code=200, json_data=None):
         self.status_code = status_code
+        self.json_data = json_data or {}
         self.post_args = []
         self.cookies = requests.cookies.RequestsCookieJar()
 
-    def post(self, url, data=None, **kwargs):
-        self.post_args.append((url, data))
+    def post(self, url, data=None, files=None, **kwargs):
+        self.post_args.append((url, data, files))
         resp = type('Resp', (), {})()
         resp.status_code = self.status_code
         resp.cookies = requests.cookies.RequestsCookieJar()
         resp.cookies.set('sid', 'cookie')
+        def raise_for_status():
+            if resp.status_code >= 400:
+                raise requests.HTTPError(resp.status_code)
+        resp.raise_for_status = raise_for_status
+        def json_func():
+            return self.json_data
+        resp.json = json_func
         # mimic requests.Session behavior updating cookies
         self.cookies.update(resp.cookies)
         return resp
@@ -33,3 +41,25 @@ def test_login_failure():
     client = NoteClient(cfg, session=session)
     with pytest.raises(NoteAuthError):
         client.login()
+
+
+def test_upload_image_success(tmp_path):
+    cfg = {'note': {'base_url': 'http://host'}}
+    session = DummySession(200, json_data={'url': 'http://cdn/x.png'})
+    client = NoteClient(cfg, session=session)
+    img = tmp_path / 'img.txt'
+    img.write_text('data')
+    url = client.upload_image(img)
+    assert url == 'http://cdn/x.png'
+    assert session.post_args[0][0] == 'http://host/api/v1/upload_image'
+    assert 'file' in session.post_args[0][2]
+
+
+def test_upload_image_failure(tmp_path):
+    cfg = {'note': {'base_url': 'http://host'}}
+    session = DummySession(500)
+    client = NoteClient(cfg, session=session)
+    img = tmp_path / 'img.txt'
+    img.write_text('data')
+    with pytest.raises(RuntimeError):
+        client.upload_image(img)


### PR DESCRIPTION
## Summary
- implement `upload_image` in `note_client.py`
- add tests covering successful and failed image uploads

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b11aeafa083298d8fb158fa2a1b05