### PR TITLE
Implement create_draft for NoteClient

### DIFF
--- a/note_client.py
+++ b/note_client.py
@@ -36,3 +36,27 @@ class NoteClient:
             return data.get("url") or data["cdn_url"]
         except Exception as exc:  # Mimic the simple try/except pattern
             raise RuntimeError(f"Image upload failed: {exc}") from exc
+
+    def create_draft(self, title: str, body_html: str) -> dict:
+        """Create a draft text note and return identifiers."""
+        post_url = f"{self.base_url}/api/v1/text_notes"
+        try:
+            resp = self.session.post(post_url, json={"title": title})
+            resp.raise_for_status()
+            data = resp.json()
+            note_id = data.get("id")
+            note_key = data.get("key")
+            draft_url = data.get("draft_url")
+            put_url = f"{self.base_url}/api/v1/text_notes/{note_id}"
+            resp2 = self.session.put(
+                put_url,
+                json={"title": title, "body": body_html, "status": "draft"},
+            )
+            resp2.raise_for_status()
+            return {
+                "note_id": note_id,
+                "note_key": note_key,
+                "draft_url": draft_url,
+            }
+        except Exception as exc:  # Mimic the simple try/except pattern
+            raise RuntimeError(f"Draft creation failed: {exc}") from exc


### PR DESCRIPTION
## Summary
- extend NoteClient with `create_draft` method
- update DummySession to handle PUT requests
- add tests for draft creation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b12ce7eb88329b1b01d106dca241b