### PR TITLE
Add post_to_note service helper

### DIFF
--- a/services/post_to_note.py
+++ b/services/post_to_note.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+from typing import List
+
+from note_client import NoteClient
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.json"
+
+if CONFIG_PATH.exists():
+    with CONFIG_PATH.open() as fh:
+        CONFIG = json.load(fh)
+else:
+    CONFIG = {}
+
+
+def create_note_client() -> NoteClient | None:
+    """Initialize a NoteClient and log in."""
+    try:
+        client = NoteClient(CONFIG)
+        client.login()
+        return client
+    except Exception as exc:
+        print(f"Failed to init Note client: {exc}")
+        return None
+
+
+NOTE_CLIENT = create_note_client()
+
+
+def post_to_note(content: str, images: List[Path] = []) -> dict:
+    """Create a Note draft with optional images."""
+    if NOTE_CLIENT is None:
+        return {"error": "Note client unavailable"}
+
+    body = f"<p>{content}</p>"
+    for img in images:
+        try:
+            url = NOTE_CLIENT.upload_image(img)
+            body += f'<img src="{url}" />'
+        except Exception as exc:
+            return {"error": f"Image upload failed: {exc}"}
+
+    try:
+        NOTE_CLIENT.create_draft("Auto Post", body)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+    return {"posted": True}


### PR DESCRIPTION
## Summary
- add a Note posting helper in `services/post_to_note.py`
- include initialization of `NoteClient` and simple image embedding logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b13fa2fc883299e31dc6c26bb88fd