### PR TITLE
Add Note account support

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -1,7 +1,11 @@
 {
   "note": {
-    "username": "your_username",
-    "password": "your_password"
+    "accounts": {
+      "default": {
+        "username": "",
+        "password": ""
+      }
+    }
   },
   "mastodon": {
     "accounts": {


### PR DESCRIPTION
## Summary
- extend `config.sample.json` with new Note account structure
- support multiple Note accounts in server with validation and client creation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b14fdf7f483298b1d3f1c9178d802