### PR TITLE
Add note draft endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from mastodon import Mastodon
 import tweepy
 from note_client import NoteClient
+from services.post_to_note import post_to_note
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -212,6 +213,11 @@ class TwitterPostRequest(BaseModel):
     media: Optional[List[str]] = None
 
 
+class NotePostRequest(BaseModel):
+    content: str
+    images: Optional[List[str]] = None
+
+
 def post_to_mastodon(account: str, text: str, media: Optional[List[str]] = None):
     if account in MASTODON_ACCOUNT_ERRORS:
         return {"error": "Account misconfigured"}
@@ -285,6 +291,12 @@ async def mastodon_post(data: MastodonPostRequest):
 @app.post("/twitter/post")
 async def twitter_post(data: TwitterPostRequest):
     return post_to_twitter(data.account, data.text, data.media)
+
+
+@app.post("/note/draft")
+async def note_draft(data: NotePostRequest):
+    paths = [Path(p) for p in data.images] if data.images else []
+    return post_to_note(data.content, paths)
 
 if __name__ == "__main__":
     import uvicorn

--- a/services/post_to_note.py
+++ b/services/post_to_note.py
@@ -28,7 +28,7 @@ NOTE_CLIENT = create_note_client()
 
 
 def post_to_note(content: str, images: List[Path] = []) -> dict:
-    """Create a Note draft with optional images."""
+    """Create a Note draft with optional images and return draft details."""
     if NOTE_CLIENT is None:
         return {"error": "Note client unavailable"}
 
@@ -41,8 +41,8 @@ def post_to_note(content: str, images: List[Path] = []) -> dict:
             return {"error": f"Image upload failed: {exc}"}
 
     try:
-        NOTE_CLIENT.create_draft("Auto Post", body)
+        draft_info = NOTE_CLIENT.create_draft("Auto Post", body)
     except Exception as exc:
         return {"error": str(exc)}
 
-    return {"posted": True}
+    return draft_info

--- a/test_note_draft.py
+++ b/test_note_draft.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+import server
+
+
+def make_client(monkeypatch, handler=None):
+    if handler is None:
+        handler = lambda content, images: {"note_id": 1}
+    monkeypatch.setattr(server, "post_to_note", handler)
+    return TestClient(server.app)
+
+
+def test_create_draft_with_images(monkeypatch):
+    received = {}
+
+    def dummy(content, images):
+        received["content"] = content
+        received["images"] = images
+        return {"note_id": 123, "note_key": "k", "draft_url": "u"}
+
+    client = make_client(monkeypatch, dummy)
+    resp = client.post(
+        "/note/draft",
+        json={"content": "hello", "images": ["a.png", "b.png"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"note_id": 123, "note_key": "k", "draft_url": "u"}
+    assert received["content"] == "hello"
+    assert received["images"] == [Path("a.png"), Path("b.png")]
+
+
+def test_create_draft_no_images(monkeypatch):
+    received = {}
+
+    def dummy(content, images):
+        received["images"] = images
+        return {}
+
+    client = make_client(monkeypatch, dummy)
+    resp = client.post("/note/draft", json={"content": "hi"})
+    assert resp.status_code == 200
+    assert received["images"] == []
+


### PR DESCRIPTION
## Summary
- return draft info from `post_to_note`
- import `post_to_note` service in server
- define `NotePostRequest` model and `/note/draft` route
- test note draft route

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b15e3b8d0832996c4c950a1a62098