### PR TITLE
Add config debug prints

### DIFF
--- a/server.py
+++ b/server.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 
 CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
+print(f"Loading config from {CONFIG_PATH}")
 
 # Load config if available
 if CONFIG_PATH.exists():
@@ -20,6 +21,7 @@ if CONFIG_PATH.exists():
         CONFIG = json.load(f)
 else:
     CONFIG = {}
+print(json.dumps(CONFIG.get('note', {}), indent=2))
 
 app = FastAPI(title="autoPoster")
 


### PR DESCRIPTION
## Summary
- print path to config when starting `server.py`
- show loaded Note config after parsing `config.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b55058a908329b4fbd5e9113798ed