### PR TITLE
Add debug output for Note login

### DIFF
--- a/note_client.py
+++ b/note_client.py
@@ -22,6 +22,7 @@ class NoteClient:
         url = f"{self.base_url}/api/v1/sessions/sign_in"
         resp = self.session.post(url, data={"login": username, "password": password})
         self.session.cookies.update(resp.cookies)
+        print(f'Login status: {resp.status_code}, body: {resp.text}')
         if resp.status_code != 200:
             raise NoteAuthError(f"Login failed with status {resp.status_code}")
 

--- a/tests/test_note_client.py
+++ b/tests/test_note_client.py
@@ -21,6 +21,7 @@ class DummySession:
         resp.status_code = self.status_code
         resp.cookies = requests.cookies.RequestsCookieJar()
         resp.cookies.set('sid', 'cookie')
+        resp.text = ''
         def raise_for_status():
             if resp.status_code >= 400:
                 raise requests.HTTPError(resp.status_code)


### PR DESCRIPTION
## Summary
- print login response status and body in `note_client.login`
- update test helper to include `text` on dummy response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b56660be88329adaff161931bd38e