### PR TITLE
Allow login with Note 201 status

### DIFF
--- a/note_client.py
+++ b/note_client.py
@@ -23,7 +23,7 @@ class NoteClient:
         resp = self.session.post(url, data={"login": username, "password": password})
         self.session.cookies.update(resp.cookies)
         print(f'Login status: {resp.status_code}, body: {resp.text}')
-        if resp.status_code != 200:
+        if resp.status_code not in (200, 201):
             raise NoteAuthError(f"Login failed with status {resp.status_code}")
 
     def upload_image(self, path: Path) -> str:

--- a/tests/test_note_client.py
+++ b/tests/test_note_client.py
@@ -55,6 +55,15 @@ def test_login_success():
     assert session.post_args[0][1] == {'login': 'u', 'password': 'p'}
     assert session.cookies.get('sid') == 'cookie'
 
+def test_login_success_201():
+    cfg = {'note': {'username': 'u', 'password': 'p', 'base_url': 'http://host'}}
+    session = DummySession(201)
+    client = NoteClient(cfg, session=session)
+    client.login()
+    assert session.post_args[0][0] == 'http://host/api/v1/sessions/sign_in'
+    assert session.post_args[0][1] == {'login': 'u', 'password': 'p'}
+    assert session.cookies.get('sid') == 'cookie'
+
 def test_login_failure():
     cfg = {'note': {'username': 'u', 'password': 'p', 'base_url': 'http://host'}}
     session = DummySession(401)


### PR DESCRIPTION
## Summary
- update `NoteClient.login()` to treat HTTP 201 as success
- add unit test for login status 201

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b5f1569788329b39bc32ea87e4221