### PR TITLE
Add account support for Note drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,13 @@ Example using `curl`:
 
 ### `POST /note/draft`
 
-Create a draft on your Note account. Send the text in `content` and optionally
-include base64 encoded images in the `images` list.
+Create a draft on a configured Note account. Specify the account name in
+`account`, send the draft text in `content`, and optionally include base64
+encoded images in the `images` list.
 
 ```json
 {
+  "account": "default",
   "content": "Hello Note",
   "images": ["base64image"]
 }
@@ -153,7 +155,7 @@ Example using `curl`:
 ```bash
 curl -X POST http://localhost:8765/note/draft \
      -H 'Content-Type: application/json' \
-     -d '{"content": "Hello Note", "images": ["b64"]}'
+     -d '{"account": "default", "content": "Hello Note", "images": ["b64"]}'
 ```
 
 ## Troubleshooting

--- a/send_note_draft.py
+++ b/send_note_draft.py
@@ -13,6 +13,7 @@ def main():
         image_b64 = base64.b64encode(f.read()).decode("utf-8")
 
     payload = {
+        "account": "default",
         "content": CONTENT,
         "images": [image_b64],
     }

--- a/server.py
+++ b/server.py
@@ -216,6 +216,7 @@ class TwitterPostRequest(BaseModel):
 
 
 class NotePostRequest(BaseModel):
+    account: str
     content: str
     images: Optional[List[str]] = None
 
@@ -298,7 +299,7 @@ async def twitter_post(data: TwitterPostRequest):
 @app.post("/note/draft")
 async def note_draft(data: NotePostRequest):
     paths = [Path(p) for p in data.images] if data.images else []
-    return post_to_note(data.content, paths)
+    return post_to_note(data.content, paths, data.account)
 
 if __name__ == "__main__":
     import uvicorn

--- a/test_note_draft.py
+++ b/test_note_draft.py
@@ -5,7 +5,7 @@ import server
 
 def make_client(monkeypatch, handler=None):
     if handler is None:
-        handler = lambda content, images: {"note_id": 1}
+        handler = lambda content, images, account: {"note_id": 1}
     monkeypatch.setattr(server, "post_to_note", handler)
     return TestClient(server.app)
 
@@ -13,31 +13,48 @@ def make_client(monkeypatch, handler=None):
 def test_create_draft_with_images(monkeypatch):
     received = {}
 
-    def dummy(content, images):
+    def dummy(content, images, account):
         received["content"] = content
         received["images"] = images
+        received["account"] = account
         return {"note_id": 123, "note_key": "k", "draft_url": "u"}
 
     client = make_client(monkeypatch, dummy)
     resp = client.post(
         "/note/draft",
-        json={"content": "hello", "images": ["a.png", "b.png"]},
+        json={"account": "acc1", "content": "hello", "images": ["a.png", "b.png"]},
     )
     assert resp.status_code == 200
     assert resp.json() == {"note_id": 123, "note_key": "k", "draft_url": "u"}
     assert received["content"] == "hello"
     assert received["images"] == [Path("a.png"), Path("b.png")]
+    assert received["account"] == "acc1"
 
 
 def test_create_draft_no_images(monkeypatch):
     received = {}
 
-    def dummy(content, images):
+    def dummy(content, images, account):
         received["images"] = images
+        received["account"] = account
         return {}
 
     client = make_client(monkeypatch, dummy)
-    resp = client.post("/note/draft", json={"content": "hi"})
+    resp = client.post("/note/draft", json={"account": "acc2", "content": "hi"})
     assert resp.status_code == 200
     assert received["images"] == []
+    assert received["account"] == "acc2"
+
+
+def test_account_parameter_passed(monkeypatch):
+    received = {}
+
+    def dummy(content, images, account):
+        received["account"] = account
+        return {}
+
+    client = make_client(monkeypatch, dummy)
+    resp = client.post("/note/draft", json={"account": "special", "content": "x"})
+    assert resp.status_code == 200
+    assert received["account"] == "special"
 

--- a/tests/test_note_client.py
+++ b/tests/test_note_client.py
@@ -142,6 +142,27 @@ def test_create_note_client_default(monkeypatch):
     assert client.logged_in
 
 
+def test_create_note_client_specific_account(monkeypatch):
+    cfg = {
+        'note': {
+            'base_url': 'http://host',
+            'accounts': {
+                'a1': {'username': 'u1', 'password': 'p1'},
+                'a2': {'username': 'u2', 'password': 'p2'},
+            },
+        }
+    }
+    import services.post_to_note as mod
+    monkeypatch.setattr(mod, 'CONFIG', cfg, raising=False)
+    monkeypatch.setattr(mod, 'NoteClient', DummyNoteClient)
+    client = mod.create_note_client('a2')
+    assert isinstance(client, DummyNoteClient)
+    assert client.cfg['note']['username'] == 'u2'
+    assert client.cfg['note']['password'] == 'p2'
+    assert client.cfg['note']['base_url'] == 'http://host'
+    assert client.logged_in
+
+
 def test_create_note_client_no_accounts(monkeypatch):
     cfg = {'note': {'accounts': {}}}
     import services.post_to_note as mod


### PR DESCRIPTION
## Summary
- allow choosing Note account when creating drafts
- extend post_to_note to load NoteClient for that account
- update draft sending script
- document account option in README
- test account handling for Note drafts and create_note_client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6280619c83299bb8f85f5bd21979