### PR TITLE
Fix note draft client and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,15 @@ Example using `curl`:
 ### `POST /note/draft`
 
 Create a draft on a configured Note account. Specify the account name in
-`account`, send the draft text in `content`, and optionally include base64
-encoded images in the `images` list.
+`account`, send the draft text in `content`, and optionally include images by
+providing a list of **file paths** in the `images` list. Each path should point
+to a file accessible to the server and will be uploaded as part of the draft.
 
 ```json
 {
   "account": "default",
   "content": "Hello Note",
-  "images": ["base64image"]
+  "images": ["example/test.png"]
 }
 ```
 
@@ -155,7 +156,7 @@ Example using `curl`:
 ```bash
 curl -X POST http://localhost:8765/note/draft \
      -H 'Content-Type: application/json' \
-     -d '{"account": "default", "content": "Hello Note", "images": ["b64"]}'
+     -d '{"account": "default", "content": "Hello Note", "images": ["example/test.png"]}'
 ```
 
 ## Troubleshooting

--- a/send_note_draft.py
+++ b/send_note_draft.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import requests
 
@@ -8,14 +7,10 @@ IMAGE_PATH = "example/b6701f05-1e2e-4776-a7c3-69c13c469514.png"  # replace with 
 
 
 def main():
-    # Read the image file and encode as base64
-    with open(IMAGE_PATH, "rb") as f:
-        image_b64 = base64.b64encode(f.read()).decode("utf-8")
-
     payload = {
         "account": "default",
         "content": CONTENT,
-        "images": [image_b64],
+        "images": [IMAGE_PATH],
     }
 
     headers = {"Content-Type": "application/json"}

--- a/services/post_to_note.py
+++ b/services/post_to_note.py
@@ -58,6 +58,8 @@ def post_to_note(content: str, images: List[Path] = [], account: str | None = No
 
     body = f"<p>{content}</p>"
     for img in images:
+        if not img.exists():
+            return {"error": f"Image file not found: {img}"}
         try:
             url = client.upload_image(img)
             body += f'<img src="{url}" />'


### PR DESCRIPTION
## Summary
- clarify that `/note/draft` expects paths for images
- send image paths directly from `send_note_draft.py`
- validate path existence in `post_to_note`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6b25ddf883299524661607d725d0