### PR TITLE
Add Note draft improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ Example using `curl`:
 Create a draft on a configured Note account. Specify the account name in
 `account`, send the draft text in `content`, and optionally include images by
 providing a list of **file paths** in the `images` list. Each path should point
-to a file accessible to the server and will be uploaded as part of the draft.
+to a file accessible to the server and will be uploaded via
+`/api/v1/upload_image` before being inserted into the draft body.
 
 ```json
 {

--- a/tests/test_note_client.py
+++ b/tests/test_note_client.py
@@ -15,8 +15,9 @@ class DummySession:
         self.put_args = []
         self.cookies = requests.cookies.RequestsCookieJar()
 
-    def post(self, url, data=None, files=None, **kwargs):
-        self.post_args.append((url, data, files))
+    def post(self, url, data=None, files=None, json=None, **kwargs):
+        payload = json if json is not None else data
+        self.post_args.append((url, payload, files))
         resp = type('Resp', (), {})()
         resp.status_code = self.status_code
         resp.cookies = requests.cookies.RequestsCookieJar()


### PR DESCRIPTION
## Summary
- support JSON login payload for Note API
- handle nested fields in upload_image
- send proper body when creating drafts
- document Note draft endpoint behavior
- adjust tests for updated login flow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b0a9dbb088329957585b8ffbee9d6