### PR TITLE
Add WordPress configuration sample

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -25,5 +25,16 @@
         "bearer_token": "YOUR_BEARER_TOKEN"
       }
     }
+  },
+  "wordpress": {
+    "accounts": {
+      "account1": {
+        "site": "https://wordpress.example",
+        "client_id": "YOUR_CLIENT_ID",
+        "client_secret": "YOUR_CLIENT_SECRET",
+        "username": "YOUR_USERNAME",
+        "password": "YOUR_PASSWORD"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add WordPress sample configuration with site, client, and credentials fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dc1fc84508329a8772a9d0df63150