### PR TITLE
Add WordPress posting service and tests

### DIFF
--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+from typing import List
+
+from wordpress_client import WordpressClient
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.json"
+
+if CONFIG_PATH.exists():
+    with CONFIG_PATH.open() as fh:
+        CONFIG = json.load(fh)
+else:
+    CONFIG = {}
+
+
+def create_wp_client(account: str | None = None) -> WordpressClient | None:
+    """Initialize a WordpressClient using the specified account."""
+    wp_cfg = CONFIG.get("wordpress", {})
+    accounts = wp_cfg.get("accounts") or {}
+    if not accounts:
+        print("No WordPress accounts configured")
+        return None
+
+    acct = None
+    if account:
+        acct = accounts.get(account)
+        if not acct:
+            print(f"No WordPress account configured for {account}")
+            return None
+    elif "default" in accounts:
+        acct = accounts["default"]
+    else:
+        acct = next(iter(accounts.values()))
+
+    cfg = {"wordpress": {"accounts": {"default": acct}}}
+
+    try:
+        client = WordpressClient(cfg)
+        client.authenticate()
+        return client
+    except Exception as exc:
+        print(f"Failed to init WordPress client: {exc}")
+        print(f"CONFIG used for WordpressClient: {cfg}")
+        return None
+
+
+WP_CLIENT = create_wp_client()
+
+
+def post_to_wordpress(
+    title: str,
+    content: str,
+    images: List[Path] = [],
+    account: str | None = None,
+) -> dict:
+    """Create a WordPress post with optional images."""
+    client = WP_CLIENT if account is None else create_wp_client(account)
+    if client is None:
+        print("WP_CLIENT is None")
+        return {"error": "WordPress client unavailable"}
+
+    body = f"<p>{content}</p>"
+    featured_id = None
+    for img in images:
+        if not img.exists():
+            return {"error": f"Image file not found: {img}"}
+        try:
+            with img.open("rb") as fh:
+                uploaded = client.upload_media(fh.read(), img.name)
+        except Exception as exc:
+            return {"error": f"Image upload failed: {exc}"}
+        url = uploaded.get("url")
+        body += f'<img src="{url}" />'
+        if featured_id is None:
+            featured_id = uploaded.get("id")
+
+    try:
+        post_info = client.create_post(title, body, featured_id)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+    return post_info

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import services.post_to_wordpress as wp_service
+
+
+class DummyClient:
+    def __init__(self, config):
+        self.config = config
+        self.authenticated = False
+        self.uploaded = []
+        self.created = None
+
+    def authenticate(self):
+        self.authenticated = True
+
+    def upload_media(self, content, filename):
+        self.uploaded.append((filename, content))
+        idx = len(self.uploaded)
+        return {"id": idx, "url": f"http://img{idx}"}
+
+    def create_post(self, title, html, featured_id=None):
+        self.created = {
+            "title": title,
+            "html": html,
+            "featured_id": featured_id,
+        }
+        return {"id": 10, "link": "http://post"}
+
+
+def test_create_wp_client_select_account(monkeypatch):
+    # Patch WordpressClient with dummy implementation
+    monkeypatch.setattr(wp_service, "WordpressClient", DummyClient)
+    wp_service.CONFIG = {
+        "wordpress": {
+            "accounts": {
+                "acc1": {"site": "s1"},
+                "acc2": {"site": "s2"},
+            }
+        }
+    }
+    client = wp_service.create_wp_client("acc2")
+    assert isinstance(client, DummyClient)
+    assert client.authenticated is True
+    # Ensure the correct account was used as default
+    assert (
+        client.config["wordpress"]["accounts"]["default"]["site"]
+        == "s2"
+    )
+
+
+def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
+    dummy = DummyClient({})
+    monkeypatch.setattr(wp_service, "create_wp_client", lambda account=None: dummy)
+
+    img1 = tmp_path / "a.jpg"
+    img1.write_bytes(b"123")
+    img2 = tmp_path / "b.jpg"
+    img2.write_bytes(b"456")
+
+    resp = wp_service.post_to_wordpress(
+        "Title", "Body", [img1, img2], account="acc"
+    )
+    assert resp == {"id": 10, "link": "http://post"}
+    # Uploaded both images
+    assert dummy.uploaded[0][0] == "a.jpg"
+    assert dummy.uploaded[1][0] == "b.jpg"
+    # HTML contains image tags
+    assert '<img src="http://img1" />' in dummy.created["html"]
+    assert '<img src="http://img2" />' in dummy.created["html"]
+    # First image used as featured
+    assert dummy.created["featured_id"] == 1


### PR DESCRIPTION
## Summary
- Implement WordPress posting utility that selects accounts from `config.json`, authenticates, uploads media and publishes posts.
- Add tests validating WordPress client creation and posting logic.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dc48327288329a6e207a19957ceea