### PR TITLE
Add CI workflow for WordPress tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,22 @@
+name: Python tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest so WordPress tests are exercised in CI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dca789ad483298753f0d1ae7382c6