### PR TITLE
Use WordPress REST v1.1 with featured image support

### DIFF
--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -31,7 +31,7 @@ def make_client(monkeypatch, config):
         if url.endswith("oauth2/token"):
             return DummyResponse({"access_token": "tok"})
         if url.endswith("/media/new"):
-            calls["uploads"].append(kwargs["files"]["file"])
+            calls["uploads"].append(kwargs["files"]["media[]"])
             return DummyResponse({"id": 1, "source_url": "http://img"})
         if url.endswith("/posts/new"):
             calls["post"] = kwargs.get("json")
@@ -84,7 +84,7 @@ def test_wordpress_post_success(monkeypatch):
     filename, content = calls["uploads"][0]
     assert content == data
     payload = calls["post"]
-    assert payload["featured_media"] == 1
+    assert payload["featured_image"] == 1
     assert "http://img" in payload["content"]
     assert payload["title"] == "T"
 

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -9,7 +9,7 @@ class WordpressClient:
     """Simple client for WordPress.com API."""
 
     TOKEN_URL = "https://public-api.wordpress.com/oauth2/token"
-    API_BASE = "https://public-api.wordpress.com/wp/v2/sites/{site}"
+    API_BASE = "https://public-api.wordpress.com/rest/v1.1/sites/{site}"
 
     def __init__(self, config: dict, session: requests.Session | None = None):
         self.config = config or {}
@@ -50,7 +50,7 @@ class WordpressClient:
     def upload_media(self, content: bytes, filename: str) -> dict:
         """Upload media bytes and return media ID and URL."""
         url = f"{self.API_BASE.format(site=self.site)}/media/new"
-        files = {"file": (filename, content)}
+        files = {"media[]": (filename, content)}
         try:
             resp = self.session.post(url, files=files)
             resp.raise_for_status()
@@ -64,7 +64,7 @@ class WordpressClient:
         url = f"{self.API_BASE.format(site=self.site)}/posts/new"
         payload = {"title": title, "content": html, "status": "publish"}
         if featured_id:
-            payload["featured_media"] = featured_id
+            payload["featured_image"] = featured_id
         try:
             resp = self.session.post(url, json=payload)
             resp.raise_for_status()


### PR DESCRIPTION
## Summary
- switch WordPress API base to REST v1.1
- upload media using `media[]` key
- send `featured_image` when creating posts
- update WordPress posting tests for new API fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dd54af0bc8329b10d193aa600a140