### PR TITLE
Specify WordPress scope

### DIFF
--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -35,6 +35,7 @@ class WordpressClient:
             "client_secret": self.client_secret,
             "username": self.username,
             "password": self.password,
+            "scope": "global",
         }
         try:
             resp = self.session.post(self.TOKEN_URL, data=data)


### PR DESCRIPTION
## Summary
- declare global scope during WordPress authentication to ensure proper permissions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688de1623b208329b9608e299a71af25