### PR TITLE
Improve logging for WordPress image uploads

### DIFF
--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -65,10 +65,13 @@ def post_to_wordpress(
         if not img.exists():
             return {"error": f"Image file not found: {img}"}
         try:
+            print(f"Uploading {img} ({img.stat().st_size} bytes)")
             with img.open("rb") as fh:
                 uploaded = client.upload_media(fh.read(), img.name)
+            print(f"Uploaded {img} -> {uploaded}")
         except Exception as exc:
-            return {"error": f"Image upload failed: {exc}"}
+            print(f"Failed image {img}: {exc}")
+            raise
         url = uploaded.get("url")
         body += f'<img src="{url}" />'
         if featured_id is None:


### PR DESCRIPTION
## Summary
- log each WordPress image upload with file size and result
- report and re-raise upload errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dec60d394832982edd54572026848