### PR TITLE
Handle WordPress media filenames

### DIFF
--- a/send_wordpress_post.py
+++ b/send_wordpress_post.py
@@ -1,5 +1,7 @@
 import base64
 import json
+from pathlib import Path
+
 import requests
 
 URL = "http://localhost:8765/wordpress/post"
@@ -18,7 +20,12 @@ def main():
         "account": ACCOUNT,
         "title": TITLE,
         "content": CONTENT,
-        "media": [media_b64],
+        "media": [
+            {
+                "filename": Path(MEDIA_PATH).name,
+                "data": media_b64,
+            }
+        ],
     }
 
     headers = {"Content-Type": "application/json"}

--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -50,7 +50,7 @@ WP_CLIENT = create_wp_client()
 def post_to_wordpress(
     title: str,
     content: str,
-    images: List[Path] = [],
+    images: List[tuple[Path, str]] = [],
     account: str | None = None,
 ) -> dict:
     """Create a WordPress post with optional images."""
@@ -61,16 +61,18 @@ def post_to_wordpress(
 
     body = f"<p>{content}</p>"
     featured_id = None
-    for img in images:
-        if not img.exists():
-            return {"error": f"Image file not found: {img}"}
+    for img_path, filename in images:
+        if not img_path.exists():
+            return {"error": f"Image file not found: {img_path}"}
         try:
-            print(f"Uploading {img} ({img.stat().st_size} bytes)")
-            with img.open("rb") as fh:
-                uploaded = client.upload_media(fh.read(), img.name)
-            print(f"Uploaded {img} -> {uploaded}")
+            print(
+                f"Uploading {img_path} ({img_path.stat().st_size} bytes) as {filename}"
+            )
+            with img_path.open("rb") as fh:
+                uploaded = client.upload_media(fh.read(), filename)
+            print(f"Uploaded {img_path} -> {uploaded}")
         except Exception as exc:
-            print(f"Failed image {img}: {exc}")
+            print(f"Failed image {img_path}: {exc}")
             raise
         url = uploaded.get("url")
         body += f'<img src="{url}" />'

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -76,12 +76,18 @@ def test_wordpress_post_success(monkeypatch):
     encoded = base64.b64encode(data).decode()
     resp = client.post(
         "/wordpress/post",
-        json={"account": "acc", "title": "T", "content": "C", "media": [encoded]},
+        json={
+            "account": "acc",
+            "title": "T",
+            "content": "C",
+            "media": [{"filename": "img.png", "data": encoded}],
+        },
     )
     assert resp.status_code == 200
     assert resp.json() == {"id": 10, "link": "http://post"}
     assert len(calls["uploads"]) == 1
     filename, content = calls["uploads"][0]
+    assert filename == "img.png"
     assert content == data
     payload = calls["post"]
     assert payload["featured_image"] == 1
@@ -107,7 +113,12 @@ def test_wordpress_post_misconfigured(monkeypatch):
     encoded = base64.b64encode(b"x").decode()
     resp = client.post(
         "/wordpress/post",
-        json={"account": "acc", "title": "T", "content": "C", "media": [encoded]},
+        json={
+            "account": "acc",
+            "title": "T",
+            "content": "C",
+            "media": [{"filename": "img.png", "data": encoded}],
+        },
     )
     assert resp.status_code == 200
     assert resp.json()["error"] == "Account misconfigured"

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -60,12 +60,15 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     img2.write_bytes(b"456")
 
     resp = wp_service.post_to_wordpress(
-        "Title", "Body", [img1, img2], account="acc"
+        "Title",
+        "Body",
+        [(img1, "x1.jpg"), (img2, "x2.jpg")],
+        account="acc",
     )
     assert resp == {"id": 10, "link": "http://post"}
     # Uploaded both images
-    assert dummy.uploaded[0][0] == "a.jpg"
-    assert dummy.uploaded[1][0] == "b.jpg"
+    assert dummy.uploaded[0][0] == "x1.jpg"
+    assert dummy.uploaded[1][0] == "x2.jpg"
     # HTML contains image tags
     assert '<img src="http://img1" />' in dummy.created["html"]
     assert '<img src="http://img2" />' in dummy.created["html"]


### PR DESCRIPTION
## Summary
- Support media metadata in WordPress posts by introducing a `WordpressMediaItem` model and carrying filenames through the request flow.
- Upload WordPress images with their original filenames and clean up temporary files after posting.
- Adjust example client and tests for the new media format.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec0694f588329a2e5f8d5c511e8cc