### PR TITLE
Improve WordPress media upload handling

### DIFF
--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import mimetypes
 
 import pytest
 from fastapi.testclient import TestClient
@@ -32,7 +33,7 @@ def make_client(monkeypatch, config):
             return DummyResponse({"access_token": "tok"})
         if url.endswith("/media/new"):
             calls["uploads"].append(kwargs["files"]["media[]"])
-            return DummyResponse({"id": 1, "source_url": "http://img"})
+            return DummyResponse({"media": {"ID": 1, "source_url": "http://img"}})
         if url.endswith("/posts/new"):
             calls["post"] = kwargs.get("json")
             return DummyResponse({"id": 10, "link": "http://post"})
@@ -86,9 +87,10 @@ def test_wordpress_post_success(monkeypatch):
     assert resp.status_code == 200
     assert resp.json() == {"id": 10, "link": "http://post"}
     assert len(calls["uploads"]) == 1
-    filename, content = calls["uploads"][0]
+    filename, content, mime = calls["uploads"][0]
     assert filename == "img.png"
     assert content == data
+    assert mime == mimetypes.guess_type("img.png")[0]
     payload = calls["post"]
     assert payload["featured_image"] == 1
     assert "http://img" in payload["content"]

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -1,3 +1,4 @@
+import mimetypes
 import requests
 
 
@@ -55,7 +56,8 @@ class WordpressClient:
     def upload_media(self, content: bytes, filename: str) -> dict:
         """Upload media bytes and return media ID and URL."""
         url = f"{self.API_BASE.format(site=self.site)}/media/new"
-        files = {"media[]": (filename, content)}
+        mime = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+        files = {"media[]": (filename, content, mime)}
         resp: requests.Response | None = None
         try:
             print(f"POST {url} with {filename}, {len(content)} bytes")
@@ -64,7 +66,11 @@ class WordpressClient:
             print(getattr(resp, "headers", None))
             resp.raise_for_status()
             data = resp.json()
-            return {"id": data.get("id"), "url": data.get("source_url") or data.get("link")}
+            media = data.get("media", data)
+            media_url = media.get("source_url") or media.get("URL")
+            if not media_url:
+                raise RuntimeError(f"Media URL missing in response: {data}")
+            return {"id": media.get("ID"), "url": media_url}
         except Exception as exc:
             if resp is not None:
                 print(resp.status_code, resp.text)


### PR DESCRIPTION
## Summary
- infer MIME type during WordPress media uploads
- parse media response for ID and URL with clearer errors
- adjust tests for new upload contract

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec85a1384832997b65bb512b7a492