### PR TITLE
Handle nested WordPress media response

### DIFF
--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -74,10 +74,17 @@ def post_to_wordpress(
         except Exception as exc:
             print(f"Failed image {img_path}: {exc}")
             raise
-        url = uploaded.get("url")
-        body += f'<img src="{url}" />'
+        media = uploaded.get("media")
+        url = uploaded.get("url") or uploaded.get("source_url")
+        if not url and media:
+            url = media.get("URL") or media.get("source_url")
+        if not url:
+            return {"error": "Media upload returned no URL"}
+        body += f'<img src="{url}" alt="{filename}" />'
         if featured_id is None:
             featured_id = uploaded.get("id")
+            if featured_id is None and media:
+                featured_id = media.get("ID")
 
     try:
         post_info = client.create_post(title, body, featured_id)

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -33,7 +33,7 @@ def make_client(monkeypatch, config):
             return DummyResponse({"access_token": "tok"})
         if url.endswith("/media/new"):
             calls["uploads"].append(kwargs["files"]["media[]"])
-            return DummyResponse({"media": {"ID": 1, "source_url": "http://img"}})
+            return DummyResponse({"media": {"ID": 1, "URL": "http://img"}})
         if url.endswith("/posts/new"):
             calls["post"] = kwargs.get("json")
             return DummyResponse({"id": 10, "link": "http://post"})
@@ -94,6 +94,7 @@ def test_wordpress_post_success(monkeypatch):
     payload = calls["post"]
     assert payload["featured_image"] == 1
     assert "http://img" in payload["content"]
+    assert 'alt="img.png"' in payload["content"]
     assert payload["title"] == "T"
 
 

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -1,16 +1,19 @@
 from pathlib import Path
 import sys
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import services.post_to_wordpress as wp_service
 
 
 class DummyClient:
-    def __init__(self, config):
+    def __init__(self, config, nested: bool = False):
         self.config = config
         self.authenticated = False
         self.uploaded = []
         self.created = None
+        self.nested = nested
 
     def authenticate(self):
         self.authenticated = True
@@ -18,6 +21,8 @@ class DummyClient:
     def upload_media(self, content, filename):
         self.uploaded.append((filename, content))
         idx = len(self.uploaded)
+        if self.nested:
+            return {"media": {"ID": idx, "URL": f"http://img{idx}"}}
         return {"id": idx, "url": f"http://img{idx}"}
 
     def create_post(self, title, html, featured_id=None):
@@ -50,8 +55,9 @@ def test_create_wp_client_select_account(monkeypatch):
     )
 
 
-def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
-    dummy = DummyClient({})
+@pytest.mark.parametrize("nested", [False, True])
+def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path, nested):
+    dummy = DummyClient({}, nested=nested)
     monkeypatch.setattr(wp_service, "create_wp_client", lambda account=None: dummy)
 
     img1 = tmp_path / "a.jpg"
@@ -69,8 +75,8 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     # Uploaded both images
     assert dummy.uploaded[0][0] == "x1.jpg"
     assert dummy.uploaded[1][0] == "x2.jpg"
-    # HTML contains image tags
-    assert '<img src="http://img1" />' in dummy.created["html"]
-    assert '<img src="http://img2" />' in dummy.created["html"]
+    # HTML contains image tags with alt attributes
+    assert '<img src="http://img1" alt="x1.jpg" />' in dummy.created["html"]
+    assert '<img src="http://img2" alt="x2.jpg" />' in dummy.created["html"]
     # First image used as featured
     assert dummy.created["featured_id"] == 1


### PR DESCRIPTION
## Summary
- Robust WordPress media upload handling with error on missing URL and alt-tagged image inclusion
- Support both flat and nested media upload responses in service
- Expand tests to cover nested `media` responses and confirm alt attributes in post content

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec98982ac832996ffc557a9ca9f89