### PR TITLE
Handle WordPress media array response in upload_media

### DIFF
--- a/tests/test_wordpress_client.py
+++ b/tests/test_wordpress_client.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from wordpress_client import WordpressClient
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+        self.text = "ok"
+        self.headers = {}
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+def _make_client():
+    return WordpressClient({"wordpress": {"site": "s"}})
+
+
+def test_upload_media_uses_media(monkeypatch):
+    client = _make_client()
+
+    def fake_post(url, files):
+        return DummyResp({"media": [{"id": 1, "URL": "http://example/img.jpg"}]})
+
+    monkeypatch.setattr(client.session, "post", fake_post)
+    res = client.upload_media(b"x", "a.jpg")
+    assert res == {"id": 1, "url": "http://example/img.jpg"}
+
+
+def test_upload_media_fallback_link(monkeypatch):
+    client = _make_client()
+
+    def fake_post(url, files):
+        return DummyResp({"media": [{"id": 2, "link": "http://page"}]})
+
+    monkeypatch.setattr(client.session, "post", fake_post)
+    res = client.upload_media(b"x", "a.jpg")
+    assert res == {"id": 2, "url": "http://page"}

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -64,7 +64,17 @@ class WordpressClient:
             print(getattr(resp, "headers", None))
             resp.raise_for_status()
             data = resp.json()
-            return {"id": data.get("id"), "url": data.get("source_url") or data.get("link")}
+            media = data.get("media")
+            if media:
+                item = media[0]
+                media_id = item.get("id")
+                media_url = item.get("source_url") or item.get("URL") or item.get("link")
+            else:
+                media_id = data.get("id")
+                media_url = (
+                    data.get("source_url") or data.get("URL") or data.get("link")
+                )
+            return {"id": media_id, "url": media_url}
         except Exception as exc:
             if resp is not None:
                 print(resp.status_code, resp.text)


### PR DESCRIPTION
## Summary
- extract media id and URL from `media` array when WordPress upload response includes it
- only fall back to `link` when `source_url`/`URL` missing
- test `upload_media` behavior for media array and link fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ec8acfc7483298a3861c68405e642