### PR TITLE
Guard against missing WordPress media URLs

### DIFF
--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -75,7 +75,11 @@ def post_to_wordpress(
             print(f"Failed image {img_path}: {exc}")
             raise
         url = uploaded.get("url")
-        body += f'<img src="{url}" />'
+        if not url:
+            print(f"No URL returned for {img_path}, skipping image tag")
+            continue
+        alt_text = uploaded.get("alt") or uploaded.get("title") or Path(filename).stem
+        body += f'<img src="{url}" alt="{alt_text}" />'
         if featured_id is None:
             featured_id = uploaded.get("id")
 

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -70,7 +70,7 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     assert dummy.uploaded[0][0] == "x1.jpg"
     assert dummy.uploaded[1][0] == "x2.jpg"
     # HTML contains image tags
-    assert '<img src="http://img1" />' in dummy.created["html"]
-    assert '<img src="http://img2" />' in dummy.created["html"]
+    assert '<img src="http://img1" alt="x1" />' in dummy.created["html"]
+    assert '<img src="http://img2" alt="x2" />' in dummy.created["html"]
     # First image used as featured
     assert dummy.created["featured_id"] == 1


### PR DESCRIPTION
## Summary
- Skip image tags when media upload lacks a URL
- Insert alt attributes for WordPress image tags
- Adjust tests for updated HTML output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ecbec73748329a82b739008b381de