### PR TITLE
Improve WordPress media upload testing

### DIFF
--- a/tests/test_wordpress_client.py
+++ b/tests/test_wordpress_client.py
@@ -35,6 +35,17 @@ def test_upload_media_uses_media(monkeypatch):
     assert res == {"id": 1, "url": "http://example/img.jpg"}
 
 
+def test_upload_media_source_url(monkeypatch):
+    client = _make_client()
+
+    def fake_post(url, files):
+        return DummyResp({"media": [{"id": 3, "source_url": "http://example/img2.jpg"}]})
+
+    monkeypatch.setattr(client.session, "post", fake_post)
+    res = client.upload_media(b"data", "b.jpg")
+    assert res == {"id": 3, "url": "http://example/img2.jpg"}
+
+
 def test_upload_media_fallback_link(monkeypatch):
     client = _make_client()
 

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -32,7 +32,7 @@ def make_client(monkeypatch, config):
             return DummyResponse({"access_token": "tok"})
         if url.endswith("/media/new"):
             calls["uploads"].append(kwargs["files"]["media[]"])
-            return DummyResponse({"id": 1, "source_url": "http://img"})
+            return DummyResponse({"media": [{"id": 1, "source_url": "http://img"}]})
         if url.endswith("/posts/new"):
             calls["post"] = kwargs.get("json")
             return DummyResponse({"id": 10, "link": "http://post"})


### PR DESCRIPTION
## Summary
- Adjust test server mock to return media array with `source_url`
- Add unit test ensuring `WordpressClient.upload_media` pulls URL from `source_url`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eccc121bc83299a483c2f72a9ee4a