### PR TITLE
feat: add paid content to WordPress posts

### DIFF
--- a/server.py
+++ b/server.py
@@ -297,6 +297,7 @@ class WordpressPostRequest(BaseModel):
     title: str
     content: str
     media: Optional[List[WordpressMediaItem]] = None
+    paid_content: Optional[str] = None
 
 
 def post_to_mastodon(account: str, text: str, media: Optional[List[str]] = None):
@@ -359,6 +360,7 @@ def post_to_wordpress(
     title: str,
     content: str,
     media: Optional[List[WordpressMediaItem]] = None,
+    paid_content: Optional[str] = None,
 ):
     if account in WORDPRESS_ACCOUNT_ERRORS:
         return {"error": "Account misconfigured"}
@@ -386,7 +388,9 @@ def post_to_wordpress(
                         pass
                 return {"error": f"Media upload failed: {exc}"}
 
-    result = service_post_to_wordpress(title, content, images, account)
+    result = service_post_to_wordpress(
+        title, content, images, account, paid_content=paid_content
+    )
     for p, _ in images:
         try:
             os.unlink(p)
@@ -418,7 +422,7 @@ async def twitter_post(data: TwitterPostRequest):
 @app.post("/wordpress/post")
 async def wordpress_post(data: WordpressPostRequest):
     return post_to_wordpress(
-        data.account, data.title, data.content, data.media
+        data.account, data.title, data.content, data.media, data.paid_content
     )
 
 

--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -52,6 +52,7 @@ def post_to_wordpress(
     content: str,
     images: List[tuple[Path, str]] = [],
     account: str | None = None,
+    paid_content: str | None = None,
 ) -> dict:
     """Create a WordPress post with optional images."""
     client = WP_CLIENT if account is None else create_wp_client(account)
@@ -60,6 +61,7 @@ def post_to_wordpress(
         return {"error": "WordPress client unavailable"}
 
     body = f"<p>{content}</p>"
+    paid_body = f"<p>{paid_content}</p>" if paid_content else None
     featured_id = None
     for img_path, filename in images:
         if not img_path.exists():
@@ -84,7 +86,9 @@ def post_to_wordpress(
             featured_id = uploaded.get("id")
 
     try:
-        post_info = client.create_post(title, body, featured_id)
+        post_info = client.create_post(
+            title, body, featured_id, paid_body
+        )
     except Exception as exc:
         return {"error": str(exc)}
 

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -81,6 +81,7 @@ def test_wordpress_post_success(monkeypatch):
             "title": "T",
             "content": "C",
             "media": [{"filename": "img.png", "data": encoded}],
+            "paid_content": "Paid",
         },
     )
     assert resp.status_code == 200
@@ -93,6 +94,7 @@ def test_wordpress_post_success(monkeypatch):
     assert payload["featured_image"] == 1
     assert "http://img" in payload["content"]
     assert payload["title"] == "T"
+    assert payload["paid_content"] == "<p>Paid</p>"
 
 
 def test_wordpress_post_misconfigured(monkeypatch):

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -20,11 +20,12 @@ class DummyClient:
         idx = len(self.uploaded)
         return {"id": idx, "url": f"http://img{idx}"}
 
-    def create_post(self, title, html, featured_id=None):
+    def create_post(self, title, html, featured_id=None, paid_content=None):
         self.created = {
             "title": title,
             "html": html,
             "featured_id": featured_id,
+            "paid_content": paid_content,
         }
         return {"id": 10, "link": "http://post"}
 
@@ -64,6 +65,7 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
         "Body",
         [(img1, "x1.jpg"), (img2, "x2.jpg")],
         account="acc",
+        paid_content="Paid",
     )
     assert resp == {"id": 10, "link": "http://post"}
     # Uploaded both images
@@ -74,3 +76,4 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     assert '<img src="http://img2" alt="x2" />' in dummy.created["html"]
     # First image used as featured
     assert dummy.created["featured_id"] == 1
+    assert dummy.created["paid_content"] == "<p>Paid</p>"

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -81,12 +81,20 @@ class WordpressClient:
                 print(getattr(resp, "headers", None))
             raise RuntimeError(f"Media upload failed: {exc}") from exc
 
-    def create_post(self, title: str, html: str, featured_id: int | None = None) -> dict:
+    def create_post(
+        self,
+        title: str,
+        html: str,
+        featured_id: int | None = None,
+        paid_content: str | None = None,
+    ) -> dict:
         """Create and publish a post with optional featured image."""
         url = f"{self.API_BASE.format(site=self.site)}/posts/new"
         payload = {"title": title, "content": html, "status": "publish"}
         if featured_id:
             payload["featured_image"] = featured_id
+        if paid_content is not None:
+            payload["paid_content"] = paid_content
         resp: requests.Response | None = None
         try:
             resp = self.session.post(url, json=payload)


### PR DESCRIPTION
## Summary
- support optional `paid_content` when posting to WordPress
- plumb `paid_content` through service layer and WordPress client
- test `paid_content` upload path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ee99e216c8329a14f83fcf0901879