### PR TITLE
Handle paid content block in WordPress posts

### DIFF
--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -61,7 +61,6 @@ def post_to_wordpress(
         return {"error": "WordPress client unavailable"}
 
     body = f"<p>{content}</p>"
-    paid_body = f"<p>{paid_content}</p>" if paid_content else None
     featured_id = None
     for img_path, filename in images:
         if not img_path.exists():
@@ -85,10 +84,15 @@ def post_to_wordpress(
         if featured_id is None:
             featured_id = uploaded.get("id")
 
-    try:
-        post_info = client.create_post(
-            title, body, featured_id, paid_body
+    if paid_content:
+        body += (
+            "<!-- wp:premium-content/paid-block -->"
+            f"<p>{paid_content}</p>"
+            "<!-- /wp:premium-content/paid-block -->"
         )
+
+    try:
+        post_info = client.create_post(title, body, featured_id)
     except Exception as exc:
         return {"error": str(exc)}
 

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -94,7 +94,9 @@ def test_wordpress_post_success(monkeypatch):
     assert payload["featured_image"] == 1
     assert "http://img" in payload["content"]
     assert payload["title"] == "T"
-    assert payload["paid_content"] == "<p>Paid</p>"
+    assert "wp:premium-content/paid-block" in payload["content"]
+    assert "<p>Paid</p>" in payload["content"]
+    assert "paid_content" not in payload
 
 
 def test_wordpress_post_misconfigured(monkeypatch):

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -76,4 +76,7 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     assert '<img src="http://img2" alt="x2" />' in dummy.created["html"]
     # First image used as featured
     assert dummy.created["featured_id"] == 1
-    assert dummy.created["paid_content"] == "<p>Paid</p>"
+    # Paid content added as block in HTML and not sent separately
+    assert "wp:premium-content/paid-block" in dummy.created["html"]
+    assert "<p>Paid</p>" in dummy.created["html"]
+    assert dummy.created["paid_content"] is None


### PR DESCRIPTION
## Summary
- allow WordPress posts to include optional paid content
- embed paid content inside a `wp:premium-content/paid-block` before posting
- update tests for new premium content block behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eeb0b2d588329be27b48aa3b12a3f