### PR TITLE
Add paid content to WordPress post payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,15 +174,18 @@ Create and publish a post on WordPress.com. The JSON body must specify the
 target `account` (matching `wordpress.accounts` in `config.json`), a `title`,
 and `content`. Optionally include `media`, a list of base64‑encoded images. Each
 image is uploaded and inserted into the post body; the first uploaded image is
-also set as the featured image (アイキャッチ). Ensure your files are within
-WordPress's upload limits and in supported formats such as PNG or JPEG.
+also set as the featured image (アイキャッチ). You can add a premium content
+section by providing `paid_content`; omit the field to skip the block. Ensure
+your files are within WordPress's upload limits and in supported formats such as
+PNG or JPEG.
 
 ```json
 {
   "account": "account1",
   "title": "Hello WP",
   "content": "Article body",
-  "media": ["base64image"]
+  "media": ["base64image"],
+  "paid_content": "Subscriber only text"
 }
 ```
 
@@ -191,7 +194,7 @@ Example using `curl`:
 ```bash
 curl -X POST http://localhost:8765/wordpress/post \
      -H 'Content-Type: application/json' \
-     -d '{"account": "account1", "title": "Hello WP", "content": "Article body", "media": ["b64"]}'
+     -d '{"account": "account1", "title": "Hello WP", "content": "Article body", "media": ["b64"], "paid_content": "Subscriber only text"}'
 ```
 
 ### `POST /note/draft`

--- a/send_wordpress_post.py
+++ b/send_wordpress_post.py
@@ -9,6 +9,9 @@ ACCOUNT = "nicchi"  # must match an entry in config.json
 TITLE = "これはWordPressへの自動投稿テストです"
 CONTENT = "自動投稿された記事の本文です"
 MEDIA_PATH = "example/b6701f05-1e2e-4776-a7c3-69c13c469514.png"  # replace with an actual file path
+# Text visible only to paid subscribers. Replace with your own text or set to
+# ``None`` to omit the paid block entirely.
+PAID_CONTENT = "ここから先は有料会員限定です"
 
 
 def main():
@@ -26,6 +29,9 @@ def main():
                 "data": media_b64,
             }
         ],
+        # Remove this key or set ``PAID_CONTENT`` to ``None`` if you do not want
+        # to include a premium content block in the post.
+        "paid_content": PAID_CONTENT,
     }
 
     headers = {"Content-Type": "application/json"}


### PR DESCRIPTION
## Summary
- support a `PAID_CONTENT` section in WordPress posts
- document the optional `paid_content` field in README examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eebf8fb008329b0d7ad0380b0eee4