### PR TITLE
test: cover paid content block

### DIFF
--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -99,6 +99,38 @@ def test_wordpress_post_success(monkeypatch):
     assert "paid_content" not in payload
 
 
+def test_wordpress_post_paid_block(monkeypatch):
+    cfg = {
+        "wordpress": {
+            "accounts": {
+                "acc": {
+                    "site": "mysite",
+                    "client_id": "id",
+                    "client_secret": "sec",
+                    "username": "user",
+                    "password": "pwd",
+                }
+            }
+        }
+    }
+    client, calls = make_client(monkeypatch, cfg)
+    resp = client.post(
+        "/wordpress/post",
+        json={
+            "account": "acc",
+            "title": "T",
+            "content": "C",
+            "paid_content": "Secret",
+        },
+    )
+    assert resp.status_code == 200
+    payload = calls["post"]
+    assert payload["title"] == "T"
+    assert "wp:premium-content/paid-block" in payload["content"]
+    assert "<p>Secret</p>" in payload["content"]
+    assert "paid_content" not in payload
+
+
 def test_wordpress_post_misconfigured(monkeypatch):
     cfg = {
         "wordpress": {

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -80,3 +80,20 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     assert "wp:premium-content/paid-block" in dummy.created["html"]
     assert "<p>Paid</p>" in dummy.created["html"]
     assert dummy.created["paid_content"] is None
+
+
+def test_post_to_wordpress_adds_paid_block(monkeypatch):
+    dummy = DummyClient({})
+    monkeypatch.setattr(wp_service, "create_wp_client", lambda account=None: dummy)
+
+    resp = wp_service.post_to_wordpress(
+        "T",
+        "B",
+        [],
+        account="acc",
+        paid_content="Secret",
+    )
+    assert resp == {"id": 10, "link": "http://post"}
+    assert "wp:premium-content/paid-block" in dummy.created["html"]
+    assert "<p>Secret</p>" in dummy.created["html"]
+    assert dummy.created["paid_content"] is None


### PR DESCRIPTION
## Summary
- add minimal service test ensuring paid content becomes premium block
- extend FastAPI WordPress tests with paid content block check

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eeced1d84832990580086cbbf0e61