### PR TITLE
docs: document paid_content option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,17 +174,38 @@ Create and publish a post on WordPress.com. The JSON body must specify the
 target `account` (matching `wordpress.accounts` in `config.json`), a `title`,
 and `content`. Optionally include `media`, a list of base64‑encoded images. Each
 image is uploaded and inserted into the post body; the first uploaded image is
-also set as the featured image (アイキャッチ). You can add a premium content
-section by providing `paid_content`; omit the field to skip the block. Ensure
-your files are within WordPress's upload limits and in supported formats such as
-PNG or JPEG.
+also set as the featured image (アイキャッチ). Ensure your files are within
+WordPress's upload limits and in supported formats such as PNG or JPEG.
 
 ```json
 {
   "account": "account1",
   "title": "Hello WP",
   "content": "Article body",
-  "media": ["base64image"],
+  "media": ["base64image"]
+}
+```
+
+Example using `curl`:
+
+```bash
+curl -X POST http://localhost:8765/wordpress/post \
+     -H 'Content-Type: application/json' \
+     -d '{"account": "account1", "title": "Hello WP", "content": "Article body", "media": ["b64"]}'
+```
+
+#### Premium content (`paid_content`)
+
+Use the optional `paid_content` field to insert a Premium Content block that is
+visible only to paying subscribers. This feature requires a WordPress.com plan
+that supports the Premium Content block (for example, the Creator or Commerce
+plan). Include the text for subscribers in the `paid_content` field:
+
+```json
+{
+  "account": "account1",
+  "title": "Hello WP",
+  "content": "Article body",
   "paid_content": "Subscriber only text"
 }
 ```
@@ -194,7 +215,7 @@ Example using `curl`:
 ```bash
 curl -X POST http://localhost:8765/wordpress/post \
      -H 'Content-Type: application/json' \
-     -d '{"account": "account1", "title": "Hello WP", "content": "Article body", "media": ["b64"], "paid_content": "Subscriber only text"}'
+     -d '{"account": "account1", "title": "Hello WP", "content": "Article body", "paid_content": "Subscriber only text"}'
 ```
 
 ### `POST /note/draft`


### PR DESCRIPTION
## Summary
- document optional `paid_content` field for WordPress posts
- note premium content block prerequisites and provide sample request

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eedefb6e083299ee5779b60bedad9