### PR TITLE
Add premium content options to WordPress posting

### DIFF
--- a/server.py
+++ b/server.py
@@ -298,6 +298,9 @@ class WordpressPostRequest(BaseModel):
     content: str
     media: Optional[List[WordpressMediaItem]] = None
     paid_content: Optional[str] = None
+    paid_title: Optional[str] = None
+    paid_message: Optional[str] = None
+    plan_id: Optional[str] = None
 
 
 def post_to_mastodon(account: str, text: str, media: Optional[List[str]] = None):
@@ -361,6 +364,9 @@ def post_to_wordpress(
     content: str,
     media: Optional[List[WordpressMediaItem]] = None,
     paid_content: Optional[str] = None,
+    paid_title: Optional[str] = None,
+    paid_message: Optional[str] = None,
+    plan_id: Optional[str] = None,
 ):
     if account in WORDPRESS_ACCOUNT_ERRORS:
         return {"error": "Account misconfigured"}
@@ -389,7 +395,14 @@ def post_to_wordpress(
                 return {"error": f"Media upload failed: {exc}"}
 
     result = service_post_to_wordpress(
-        title, content, images, account, paid_content=paid_content
+        title,
+        content,
+        images,
+        account,
+        paid_content=paid_content,
+        paid_title=paid_title,
+        paid_message=paid_message,
+        plan_id=plan_id,
     )
     for p, _ in images:
         try:
@@ -422,7 +435,14 @@ async def twitter_post(data: TwitterPostRequest):
 @app.post("/wordpress/post")
 async def wordpress_post(data: WordpressPostRequest):
     return post_to_wordpress(
-        data.account, data.title, data.content, data.media, data.paid_content
+        data.account,
+        data.title,
+        data.content,
+        data.media,
+        data.paid_content,
+        data.paid_title,
+        data.paid_message,
+        data.plan_id,
     )
 
 

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -82,6 +82,9 @@ def test_wordpress_post_success(monkeypatch):
             "content": "C",
             "media": [{"filename": "img.png", "data": encoded}],
             "paid_content": "Paid",
+            "paid_title": "PT",
+            "paid_message": "Msg",
+            "plan_id": "p1",
         },
     )
     assert resp.status_code == 200
@@ -95,7 +98,10 @@ def test_wordpress_post_success(monkeypatch):
     assert "http://img" in payload["content"]
     assert payload["title"] == "T"
     assert "wp:premium-content/paid-block" in payload["content"]
+    assert "<h2>PT</h2>" in payload["content"]
     assert "<p>Paid</p>" in payload["content"]
+    assert '"message": "Msg"' in payload["content"]
+    assert '"planId": "p1"' in payload["content"]
     assert "paid_content" not in payload
 
 
@@ -109,6 +115,7 @@ def test_wordpress_post_paid_block(monkeypatch):
                     "client_secret": "sec",
                     "username": "user",
                     "password": "pwd",
+                    "plan_id": "cfg",
                 }
             }
         }
@@ -121,13 +128,18 @@ def test_wordpress_post_paid_block(monkeypatch):
             "title": "T",
             "content": "C",
             "paid_content": "Secret",
+            "paid_title": "Hidden",
+            "paid_message": "M",
         },
     )
     assert resp.status_code == 200
     payload = calls["post"]
     assert payload["title"] == "T"
     assert "wp:premium-content/paid-block" in payload["content"]
+    assert "<h2>Hidden</h2>" in payload["content"]
     assert "<p>Secret</p>" in payload["content"]
+    assert '"message": "M"' in payload["content"]
+    assert '"planId": "cfg"' in payload["content"]
     assert "paid_content" not in payload
 
 


### PR DESCRIPTION
## Summary
- allow passing paid title, message and plan plan_id when requesting WordPress posts
- build premium-content block with optional plan and message attributes
- expose new options on `/wordpress/post` endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f0788cef483299e8ff2e6d636171a