### PR TITLE
Add WordPress premium block builder

### DIFF
--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -101,7 +101,8 @@ def test_wordpress_post_success(monkeypatch):
     assert "<h2>PT</h2>" in payload["content"]
     assert "<p>Paid</p>" in payload["content"]
     assert '"message": "Msg"' in payload["content"]
-    assert '"planId": "p1"' in payload["content"]
+    assert '"title": "PT"' in payload["content"]
+    assert '"planIds": ["p1"]' in payload["content"]
     assert "paid_content" not in payload
 
 
@@ -139,7 +140,8 @@ def test_wordpress_post_paid_block(monkeypatch):
     assert "<h2>Hidden</h2>" in payload["content"]
     assert "<p>Secret</p>" in payload["content"]
     assert '"message": "M"' in payload["content"]
-    assert '"planId": "cfg"' in payload["content"]
+    assert '"title": "Hidden"' in payload["content"]
+    assert '"planIds": ["cfg"]' in payload["content"]
     assert "paid_content" not in payload
 
 

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -90,7 +90,8 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     assert "<h2>PTitle</h2>" in dummy.created["html"]
     assert "<p>Paid</p>" in dummy.created["html"]
     assert '"message": "Msg"' in dummy.created["html"]
-    assert '"planId": "p1"' in dummy.created["html"]
+    assert '"title": "PTitle"' in dummy.created["html"]
+    assert '"planIds": ["p1"]' in dummy.created["html"]
     assert dummy.created["paid_content"] is None
 
 
@@ -112,6 +113,7 @@ def test_post_to_wordpress_adds_paid_block(monkeypatch):
     assert "<h2>Hidden</h2>" in dummy.created["html"]
     assert "<p>Secret</p>" in dummy.created["html"]
     assert '"message": "M"' in dummy.created["html"]
+    assert '"title": "Hidden"' in dummy.created["html"]
     # plan_id defaults to client's plan_id when not provided
-    assert '"planId": "cfg"' in dummy.created["html"]
+    assert '"planIds": ["cfg"]' in dummy.created["html"]
     assert dummy.created["paid_content"] is None


### PR DESCRIPTION
## Summary
- build `build_paid_block` to generate premium content blocks with plan IDs, title and message JSON attributes
- insert premium blocks via `post_to_wordpress` when paid content is present, defaulting missing values
- adjust WordPress tests for new block format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f08fc4d4883298017d739e64bb9ff