### PR TITLE
Use Jetpack subscribers-only block for paid content

### DIFF
--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -53,23 +53,23 @@ def build_paid_block(
     paid_message: str | None,
     paid_body: str,
 ) -> str:
-    """Return HTML for a WordPress premium content block."""
+    """Return HTML for a WordPress subscribers-only block."""
     # Ensure attributes have default values
     plan_id = plan_id or ""
     paid_title = paid_title or ""
     paid_message = paid_message or ""
 
     attrs = {
-        "planIds": [plan_id],
+        "planId": plan_id,
         "title": paid_title,
         "message": paid_message,
     }
     attr_json = json.dumps(attrs, ensure_ascii=False)
-    block = f"<!-- wp:premium-content/paid-block {attr_json} -->"
+    block = f"<!-- wp:jetpack/subscribers-only-content {attr_json} -->"
     if paid_title:
         block += f"<h2>{paid_title}</h2>"
     block += f"<p>{paid_body}</p>"
-    block += "<!-- /wp:premium-content/paid-block -->"
+    block += "<!-- /wp:jetpack/subscribers-only-content -->"
     return block
 
 

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -97,12 +97,12 @@ def test_wordpress_post_success(monkeypatch):
     assert payload["featured_image"] == 1
     assert "http://img" in payload["content"]
     assert payload["title"] == "T"
-    assert "wp:premium-content/paid-block" in payload["content"]
+    assert "wp:jetpack/subscribers-only-content" in payload["content"]
     assert "<h2>PT</h2>" in payload["content"]
     assert "<p>Paid</p>" in payload["content"]
     assert '"message": "Msg"' in payload["content"]
     assert '"title": "PT"' in payload["content"]
-    assert '"planIds": ["p1"]' in payload["content"]
+    assert '"planId": "p1"' in payload["content"]
     assert "paid_content" not in payload
 
 
@@ -136,12 +136,12 @@ def test_wordpress_post_paid_block(monkeypatch):
     assert resp.status_code == 200
     payload = calls["post"]
     assert payload["title"] == "T"
-    assert "wp:premium-content/paid-block" in payload["content"]
+    assert "wp:jetpack/subscribers-only-content" in payload["content"]
     assert "<h2>Hidden</h2>" in payload["content"]
     assert "<p>Secret</p>" in payload["content"]
     assert '"message": "M"' in payload["content"]
     assert '"title": "Hidden"' in payload["content"]
-    assert '"planIds": ["cfg"]' in payload["content"]
+    assert '"planId": "cfg"' in payload["content"]
     assert "paid_content" not in payload
 
 

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -85,13 +85,13 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     assert '<img src="http://img2" alt="x2" />' in dummy.created["html"]
     # First image used as featured
     assert dummy.created["featured_id"] == 1
-    # Paid content added as block in HTML and not sent separately
-    assert "wp:premium-content/paid-block" in dummy.created["html"]
+    # Paid content added as subscribers-only block in HTML and not sent separately
+    assert "wp:jetpack/subscribers-only-content" in dummy.created["html"]
     assert "<h2>PTitle</h2>" in dummy.created["html"]
     assert "<p>Paid</p>" in dummy.created["html"]
     assert '"message": "Msg"' in dummy.created["html"]
     assert '"title": "PTitle"' in dummy.created["html"]
-    assert '"planIds": ["p1"]' in dummy.created["html"]
+    assert '"planId": "p1"' in dummy.created["html"]
     assert dummy.created["paid_content"] is None
 
 
@@ -109,11 +109,11 @@ def test_post_to_wordpress_adds_paid_block(monkeypatch):
         paid_message="M",
     )
     assert resp == {"id": 10, "link": "http://post"}
-    assert "wp:premium-content/paid-block" in dummy.created["html"]
+    assert "wp:jetpack/subscribers-only-content" in dummy.created["html"]
     assert "<h2>Hidden</h2>" in dummy.created["html"]
     assert "<p>Secret</p>" in dummy.created["html"]
     assert '"message": "M"' in dummy.created["html"]
     assert '"title": "Hidden"' in dummy.created["html"]
     # plan_id defaults to client's plan_id when not provided
-    assert '"planIds": ["cfg"]' in dummy.created["html"]
+    assert '"planId": "cfg"' in dummy.created["html"]
     assert dummy.created["paid_content"] is None


### PR DESCRIPTION
## Summary
- switch premium content block generation to Jetpack subscribers-only block
- verify Jetpack paid block via WordPress service and API tests

## Testing
- `pytest tests/test_wordpress_service.py::test_post_to_wordpress_uploads_and_creates tests/test_wordpress_service.py::test_post_to_wordpress_adds_paid_block tests/test_wordpress_post.py::test_wordpress_post_success tests/test_wordpress_post.py::test_wordpress_post_paid_block tests/test_wordpress_post.py::test_wordpress_post_misconfigured -q`


------
https://chatgpt.com/codex/tasks/task_e_688f0b1d8a108329ac18a65059000e03