### PR TITLE
Add tests for WordPress service without paid content

### DIFF
--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -117,3 +117,18 @@ def test_post_to_wordpress_adds_paid_block(monkeypatch):
     # plan_id defaults to client's plan_id when not provided
     assert '"planId": "cfg"' in dummy.created["html"]
     assert dummy.created["paid_content"] is None
+
+
+def test_post_to_wordpress_without_paid_content(monkeypatch):
+    dummy = DummyClient({})
+    monkeypatch.setattr(wp_service, "create_wp_client", lambda account=None: dummy)
+
+    resp = wp_service.post_to_wordpress(
+        "Title",
+        "Body",
+        [],
+        account="acc",
+    )
+    assert resp == {"id": 10, "link": "http://post"}
+    assert "wp:jetpack/subscribers-only-content" not in dummy.created["html"]
+    assert dummy.created["paid_content"] is None


### PR DESCRIPTION
## Summary
- add coverage for `post_to_wordpress` when no paid content is specified

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892966948d0832988aa0ced4c7a1acd