### PR TITLE
Add category and tag support for WordPress posts

### DIFF
--- a/server.py
+++ b/server.py
@@ -301,6 +301,8 @@ class WordpressPostRequest(BaseModel):
     paid_title: Optional[str] = None
     paid_message: Optional[str] = None
     plan_id: Optional[str] = None
+    categories: Optional[List[str]] = None
+    tags: Optional[List[str]] = None
 
 
 def post_to_mastodon(account: str, text: str, media: Optional[List[str]] = None):
@@ -367,6 +369,8 @@ def post_to_wordpress(
     paid_title: Optional[str] = None,
     paid_message: Optional[str] = None,
     plan_id: Optional[str] = None,
+    categories: Optional[List[str]] = None,
+    tags: Optional[List[str]] = None,
 ):
     if account in WORDPRESS_ACCOUNT_ERRORS:
         return {"error": "Account misconfigured"}
@@ -403,6 +407,8 @@ def post_to_wordpress(
         paid_title=paid_title,
         paid_message=paid_message,
         plan_id=plan_id,
+        categories=categories,
+        tags=tags,
     )
     for p, _ in images:
         try:
@@ -443,6 +449,8 @@ async def wordpress_post(data: WordpressPostRequest):
         data.paid_title,
         data.paid_message,
         data.plan_id,
+        data.categories,
+        data.tags,
     )
 
 

--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -82,6 +82,8 @@ def post_to_wordpress(
     paid_title: str | None = None,
     paid_message: str | None = None,
     plan_id: str | None = None,
+    categories: list[str] | None = None,
+    tags: list[str] | None = None,
 ) -> dict:
     """Create a WordPress post with optional images."""
     client = WP_CLIENT if account is None else create_wp_client(account)
@@ -119,7 +121,13 @@ def post_to_wordpress(
         body += build_paid_block(plan, paid_title, paid_message, paid_content)
 
     try:
-        post_info = client.create_post(title, body, featured_id)
+        post_info = client.create_post(
+            title,
+            body,
+            featured_id,
+            categories=categories,
+            tags=tags,
+        )
     except Exception as exc:
         return {"error": str(exc)}
 

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -106,6 +106,37 @@ def test_wordpress_post_success(monkeypatch):
     assert "paid_content" not in payload
 
 
+def test_wordpress_post_with_categories_tags(monkeypatch):
+    cfg = {
+        "wordpress": {
+            "accounts": {
+                "acc": {
+                    "site": "mysite",
+                    "client_id": "id",
+                    "client_secret": "sec",
+                    "username": "user",
+                    "password": "pwd",
+                }
+            }
+        }
+    }
+    client, calls = make_client(monkeypatch, cfg)
+    resp = client.post(
+        "/wordpress/post",
+        json={
+            "account": "acc",
+            "title": "T",
+            "content": "C",
+            "categories": ["News", "Tech"],
+            "tags": ["python", "fastapi"],
+        },
+    )
+    assert resp.status_code == 200
+    payload = calls["post"]
+    assert payload["categories"] == "News,Tech"
+    assert payload["tags"] == "python,fastapi"
+
+
 def test_wordpress_post_paid_block(monkeypatch):
     cfg = {
         "wordpress": {

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -26,12 +26,22 @@ class DummyClient:
         idx = len(self.uploaded)
         return {"id": idx, "url": f"http://img{idx}"}
 
-    def create_post(self, title, html, featured_id=None, paid_content=None):
+    def create_post(
+        self,
+        title,
+        html,
+        featured_id=None,
+        paid_content=None,
+        categories=None,
+        tags=None,
+    ):
         self.created = {
             "title": title,
             "html": html,
             "featured_id": featured_id,
             "paid_content": paid_content,
+            "categories": categories,
+            "tags": tags,
         }
         return {"id": 10, "link": "http://post"}
 
@@ -132,3 +142,20 @@ def test_post_to_wordpress_without_paid_content(monkeypatch):
     assert resp == {"id": 10, "link": "http://post"}
     assert "wp:jetpack/subscribers-only-content" not in dummy.created["html"]
     assert dummy.created["paid_content"] is None
+
+
+def test_post_to_wordpress_categories_tags(monkeypatch):
+    dummy = DummyClient({})
+    monkeypatch.setattr(wp_service, "create_wp_client", lambda account=None: dummy)
+
+    resp = wp_service.post_to_wordpress(
+        "Title",
+        "Body",
+        [],
+        account="acc",
+        categories=["News", "Tech"],
+        tags=["python", "fastapi"],
+    )
+    assert resp == {"id": 10, "link": "http://post"}
+    assert dummy.created["categories"] == ["News", "Tech"]
+    assert dummy.created["tags"] == ["python", "fastapi"]

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -88,6 +88,8 @@ class WordpressClient:
         html: str,
         featured_id: int | None = None,
         paid_content: str | None = None,
+        categories: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> dict:
         """Create and publish a post with optional featured image."""
         url = f"{self.API_BASE.format(site=self.site)}/posts/new"
@@ -96,6 +98,10 @@ class WordpressClient:
             payload["featured_image"] = featured_id
         if paid_content is not None:
             payload["paid_content"] = paid_content
+        if categories:
+            payload["categories"] = ",".join(categories)
+        if tags:
+            payload["tags"] = ",".join(tags)
         resp: requests.Response | None = None
         try:
             resp = self.session.post(url, json=payload)


### PR DESCRIPTION
## Summary
- allow category and tag lists in WordPress post requests
- forward categories and tags through service layer to REST API
- format categories and tags appropriately in the WordPress client

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68929930c8148329af24088390ae71f1