### PR TITLE
Add categories and tags to WordPress post payload

### DIFF
--- a/send_wordpress_post.py
+++ b/send_wordpress_post.py
@@ -22,6 +22,9 @@ PAID_MESSAGE = None
 # use the plan configured for the WordPress account.
 PLAN_ID = None# これたぶん25じゃない？
 
+CATEGORIES = ["test"]
+TAGS = ["sample", "日本語テスト"]
+
 
 def main():
     # Read the media file and encode as base64
@@ -51,6 +54,8 @@ def main():
         # set ``PLAN_ID`` to ``None`` or remove the key to use the plan
         # configured for the WordPress account.
         "plan_id": PLAN_ID,
+        "categories": CATEGORIES,
+        "tags": TAGS,
     }
 
     headers = {"Content-Type": "application/json"}


### PR DESCRIPTION
## Summary
- add global CATEGORIES and TAGS constants for WordPress posts
- include categories and tags in payload when posting

## Testing
- `pytest -q`
- `python server.py &` followed by `python send_wordpress_post.py` (server responded `{"error":"Account not configured"}`)


------
https://chatgpt.com/codex/tasks/task_e_6892ad8b54fc8329becd1f4b9d283804