### PR TITLE
Ensure WordPress images scale responsively

### DIFF
--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -111,7 +111,10 @@ def post_to_wordpress(
             print(f"No URL returned for {img_path}, skipping image tag")
             continue
         alt_text = uploaded.get("alt") or uploaded.get("title") or Path(filename).stem
-        body += f'<img src="{url}" alt="{alt_text}" />'
+        body += (
+            f'<img src="{url}" alt="{alt_text}" '
+            'style="max-width:100%;height:auto;" />'
+        )
         if featured_id is None:
             featured_id = uploaded.get("id")
 

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -91,8 +91,14 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     assert dummy.uploaded[0][0] == "x1.jpg"
     assert dummy.uploaded[1][0] == "x2.jpg"
     # HTML contains image tags
-    assert '<img src="http://img1" alt="x1" />' in dummy.created["html"]
-    assert '<img src="http://img2" alt="x2" />' in dummy.created["html"]
+    assert (
+        '<img src="http://img1" alt="x1" style="max-width:100%;height:auto;" />'
+        in dummy.created["html"]
+    )
+    assert (
+        '<img src="http://img2" alt="x2" style="max-width:100%;height:auto;" />'
+        in dummy.created["html"]
+    )
     # First image used as featured
     assert dummy.created["featured_id"] == 1
     # Paid content added as subscribers-only block in HTML and not sent separately


### PR DESCRIPTION
## Summary
- apply responsive style to WordPress image tags
- update WordPress service tests for new style

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689863fefd188329b9243d015c13040c