### PR TITLE
Include site name in WordPress post responses

### DIFF
--- a/server.py
+++ b/server.py
@@ -440,7 +440,7 @@ async def twitter_post(data: TwitterPostRequest):
 
 @app.post("/wordpress/post")
 async def wordpress_post(data: WordpressPostRequest):
-    return post_to_wordpress(
+    post_info = post_to_wordpress(
         data.account,
         data.title,
         data.content,
@@ -452,6 +452,7 @@ async def wordpress_post(data: WordpressPostRequest):
         data.categories,
         data.tags,
     )
+    return post_info
 
 
 @app.post("/note/draft")

--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -133,5 +133,5 @@ def post_to_wordpress(
         )
     except Exception as exc:
         return {"error": str(exc)}
-
+    post_info = {**post_info, "site": client.site}
     return post_info

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -88,7 +88,7 @@ def test_wordpress_post_success(monkeypatch):
         },
     )
     assert resp.status_code == 200
-    assert resp.json() == {"id": 10, "link": "http://post"}
+    assert resp.json() == {"id": 10, "link": "http://post", "site": "mysite"}
     assert len(calls["uploads"]) == 1
     filename, content = calls["uploads"][0]
     assert filename == "img.png"

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -17,6 +17,7 @@ class DummyClient:
             .get("default", {})
         )
         self.plan_id = info.get("plan_id")
+        self.site = info.get("site", "mysite")
 
     def authenticate(self):
         self.authenticated = True
@@ -86,7 +87,7 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
         paid_message="Msg",
         plan_id="p1",
     )
-    assert resp == {"id": 10, "link": "http://post"}
+    assert resp == {"id": 10, "link": "http://post", "site": "mysite"}
     # Uploaded both images
     assert dummy.uploaded[0][0] == "x1.jpg"
     assert dummy.uploaded[1][0] == "x2.jpg"
@@ -124,7 +125,7 @@ def test_post_to_wordpress_adds_paid_block(monkeypatch):
         paid_title="Hidden",
         paid_message="M",
     )
-    assert resp == {"id": 10, "link": "http://post"}
+    assert resp == {"id": 10, "link": "http://post", "site": "mysite"}
     assert "wp:jetpack/subscribers-only-content" in dummy.created["html"]
     assert "<h2>Hidden</h2>" in dummy.created["html"]
     assert "<p>Secret</p>" in dummy.created["html"]
@@ -145,7 +146,7 @@ def test_post_to_wordpress_without_paid_content(monkeypatch):
         [],
         account="acc",
     )
-    assert resp == {"id": 10, "link": "http://post"}
+    assert resp == {"id": 10, "link": "http://post", "site": "mysite"}
     assert "wp:jetpack/subscribers-only-content" not in dummy.created["html"]
     assert dummy.created["paid_content"] is None
 
@@ -162,6 +163,6 @@ def test_post_to_wordpress_categories_tags(monkeypatch):
         categories=["News", "Tech"],
         tags=["python", "fastapi"],
     )
-    assert resp == {"id": 10, "link": "http://post"}
+    assert resp == {"id": 10, "link": "http://post", "site": "mysite"}
     assert dummy.created["categories"] == ["News", "Tech"]
     assert dummy.created["tags"] == ["python", "fastapi"]


### PR DESCRIPTION
## Summary
- expose WordPress site identifier from posting service
- ensure `/wordpress/post` endpoint returns post info unchanged
- update tests for new `site` field

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68986c28f57c8329afa70b23db9d01bc