### PR TITLE
Add WordPress stats views endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -10,6 +10,7 @@ from note_client import NoteClient
 from wordpress_client import WordpressClient
 from services.post_to_note import post_to_note
 from services.post_to_wordpress import post_to_wordpress as service_post_to_wordpress
+from services.wordpress_stats import get_post_views as service_get_post_views
 import os
 import tempfile
 
@@ -453,6 +454,11 @@ async def wordpress_post(data: WordpressPostRequest):
         data.tags,
     )
     return post_info
+
+
+@app.get("/wordpress/stats/views")
+async def wordpress_post_views(post_id: int, days: int, account: str | None = None):
+    return service_get_post_views(account, post_id, days)
 
 
 @app.post("/note/draft")

--- a/services/wordpress_stats.py
+++ b/services/wordpress_stats.py
@@ -1,0 +1,14 @@
+from services.post_to_wordpress import create_wp_client, WP_CLIENT
+
+
+def get_post_views(account: str | None, post_id: int, days: int) -> dict:
+    """Fetch view statistics for a WordPress post."""
+    client = WP_CLIENT if account is None else create_wp_client(account)
+    if client is None:
+        return {"error": "WordPress client unavailable"}
+    try:
+        data = client.get_post_views(post_id, days)
+    except Exception as exc:
+        return {"error": str(exc)}
+    return {"views": data.get("views")}
+

--- a/tests/test_wordpress_stats.py
+++ b/tests/test_wordpress_stats.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import server
+import wordpress_client
+import services.wordpress_stats as wp_stats
+from fastapi.testclient import TestClient
+
+
+def test_wordpress_views_endpoint(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers=None, params=None):
+        captured["url"] = url
+        captured["params"] = params
+        class DummyResp:
+            status_code = 200
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"views": [1, 2, 3]}
+        return DummyResp()
+
+    monkeypatch.setattr(wordpress_client.requests, "get", fake_get)
+
+    cfg = {"wordpress": {"accounts": {"default": {"site": "mysite"}}}}
+    client = wordpress_client.WordpressClient(cfg)
+    client.access_token = "tok"
+    client.session.headers.update({"Authorization": "Bearer tok"})
+
+    monkeypatch.setattr(wp_stats, "WP_CLIENT", client)
+    monkeypatch.setattr(wp_stats, "create_wp_client", lambda account=None: client)
+
+    app = TestClient(server.app)
+    resp = app.get(
+        "/wordpress/stats/views",
+        params={"account": "acc", "post_id": 10, "days": 5},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"views": [1, 2, 3]}
+    assert (
+        captured["url"]
+        == "https://public-api.wordpress.com/rest/v1.1/sites/mysite/stats/post/10"
+    )
+    assert captured["params"] == {"unit": "day", "quantity": 5}
+

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -112,3 +112,17 @@ class WordpressClient:
             if resp is not None:
                 print(resp.status_code, resp.text)
             raise RuntimeError(f"Post creation failed: {exc}") from exc
+
+    def get_post_views(self, post_id: int, days: int) -> dict:
+        """Return view statistics for a post over a number of days."""
+        url = f"{self.API_BASE.format(site=self.site)}/stats/post/{post_id}"
+        params = {"unit": "day", "quantity": days}
+        resp: requests.Response | None = None
+        try:
+            resp = requests.get(url, headers=self.session.headers, params=params)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            if resp is not None:
+                print(resp.status_code, resp.text)
+            raise RuntimeError(f"Fetching post views failed: {exc}") from exc


### PR DESCRIPTION
## Summary
- Implement client call to WordPress.com stats API for post views
- Provide FastAPI service and route `/wordpress/stats/views`
- Add tests validating request parameters and endpoint response

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68986e6154608329af35986096925eaf