### PR TITLE
Add WordPress search terms stats endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -10,7 +10,10 @@ from note_client import NoteClient
 from wordpress_client import WordpressClient
 from services.post_to_note import post_to_note
 from services.post_to_wordpress import post_to_wordpress as service_post_to_wordpress
-from services.wordpress_stats import get_post_views as service_get_post_views
+from services.wordpress_stats import (
+    get_post_views as service_get_post_views,
+    get_search_terms as service_get_search_terms,
+)
 import os
 import tempfile
 
@@ -459,6 +462,11 @@ async def wordpress_post(data: WordpressPostRequest):
 @app.get("/wordpress/stats/views")
 async def wordpress_post_views(post_id: int, days: int, account: str | None = None):
     return service_get_post_views(account, post_id, days)
+
+
+@app.get("/wordpress/stats/search-terms")
+async def wordpress_search_terms(days: int, account: str | None = None):
+    return service_get_search_terms(account, days)
 
 
 @app.post("/note/draft")

--- a/services/wordpress_stats.py
+++ b/services/wordpress_stats.py
@@ -12,3 +12,15 @@ def get_post_views(account: str | None, post_id: int, days: int) -> dict:
         return {"error": str(exc)}
     return {"views": data.get("views")}
 
+
+def get_search_terms(account: str | None, days: int) -> dict:
+    """Fetch search terms for a WordPress site."""
+    client = WP_CLIENT if account is None else create_wp_client(account)
+    if client is None:
+        return {"error": "WordPress client unavailable"}
+    try:
+        terms = client.get_search_terms(days)
+    except Exception as exc:
+        return {"error": str(exc)}
+    return {"terms": terms}
+

--- a/tests/test_wordpress_stats.py
+++ b/tests/test_wordpress_stats.py
@@ -45,3 +45,44 @@ def test_wordpress_views_endpoint(monkeypatch):
     )
     assert captured["params"] == {"unit": "day", "quantity": 5}
 
+
+def test_wordpress_search_terms_endpoint(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers=None, params=None):
+        captured["url"] = url
+        captured["params"] = params
+        class DummyResp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"search_terms": ["foo", "bar"]}
+
+        return DummyResp()
+
+    monkeypatch.setattr(wordpress_client.requests, "get", fake_get)
+
+    cfg = {"wordpress": {"accounts": {"default": {"site": "mysite"}}}}
+    client = wordpress_client.WordpressClient(cfg)
+    client.access_token = "tok"
+    client.session.headers.update({"Authorization": "Bearer tok"})
+
+    monkeypatch.setattr(wp_stats, "WP_CLIENT", client)
+    monkeypatch.setattr(wp_stats, "create_wp_client", lambda account=None: client)
+
+    app = TestClient(server.app)
+    resp = app.get(
+        "/wordpress/stats/search-terms",
+        params={"account": "acc", "days": 7},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"terms": ["foo", "bar"]}
+    assert (
+        captured["url"]
+        == "https://public-api.wordpress.com/rest/v1.1/sites/mysite/stats/search-terms"
+    )
+    assert captured["params"] == {"days": 7}
+

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -126,3 +126,20 @@ class WordpressClient:
             if resp is not None:
                 print(resp.status_code, resp.text)
             raise RuntimeError(f"Fetching post views failed: {exc}") from exc
+
+    def get_search_terms(self, days: int) -> list[str]:
+        """Return search terms over a number of days."""
+        url = f"{self.API_BASE.format(site=self.site)}/stats/search-terms"
+        params = {"days": days}
+        resp: requests.Response | None = None
+        try:
+            resp = requests.get(url, headers=self.session.headers, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("search_terms", [])
+        except Exception as exc:
+            if resp is not None:
+                print(resp.status_code, resp.text)
+            raise RuntimeError(
+                f"Fetching search terms failed: {exc}"
+            ) from exc


### PR DESCRIPTION
## Summary
- add `get_search_terms` method to `WordpressClient`
- expose `/wordpress/stats/search-terms` API route
- test search term stats endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68986fa68dac832994acfda784fb57c9