### PR TITLE
Document Stats API site identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,12 @@ Sample response:
 ```json
 {
   "id": 10,
-  "link": "http://post"
+  "link": "http://post",
+  "site": "your-site.wordpress.com"
 }
 ```
+
+Clients should store the `{site, id}` pair for Stats API calls.
 
 If the site does not have a plan that supports Premium Content, WordPress.com
 returns an error and the API responds with a message such as `{"error":


### PR DESCRIPTION
## Summary
- clarify `POST /wordpress/post` response format
- advise clients to store `{site, id}` for Stats API usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68987262ecc883298f2713acc87440c7