### PR TITLE
Use session for WordPress stats requests

### DIFF
--- a/tests/test_wordpress_stats.py
+++ b/tests/test_wordpress_stats.py
@@ -22,12 +22,11 @@ def test_wordpress_views_endpoint(monkeypatch):
                 return {"views": [1, 2, 3]}
         return DummyResp()
 
-    monkeypatch.setattr(wordpress_client.requests, "get", fake_get)
-
     cfg = {"wordpress": {"accounts": {"default": {"site": "mysite"}}}}
     client = wordpress_client.WordpressClient(cfg)
     client.access_token = "tok"
     client.session.headers.update({"Authorization": "Bearer tok"})
+    monkeypatch.setattr(client.session, "get", fake_get)
 
     monkeypatch.setattr(wp_stats, "WP_CLIENT", client)
     monkeypatch.setattr(wp_stats, "create_wp_client", lambda account=None: client)
@@ -63,12 +62,11 @@ def test_wordpress_search_terms_endpoint(monkeypatch):
 
         return DummyResp()
 
-    monkeypatch.setattr(wordpress_client.requests, "get", fake_get)
-
     cfg = {"wordpress": {"accounts": {"default": {"site": "mysite"}}}}
     client = wordpress_client.WordpressClient(cfg)
     client.access_token = "tok"
     client.session.headers.update({"Authorization": "Bearer tok"})
+    monkeypatch.setattr(client.session, "get", fake_get)
 
     monkeypatch.setattr(wp_stats, "WP_CLIENT", client)
     monkeypatch.setattr(wp_stats, "create_wp_client", lambda account=None: client)

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -119,7 +119,7 @@ class WordpressClient:
         params = {"unit": "day", "quantity": days}
         resp: requests.Response | None = None
         try:
-            resp = requests.get(url, headers=self.session.headers, params=params)
+            resp = self.session.get(url, headers=self.session.headers, params=params)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:
@@ -133,7 +133,7 @@ class WordpressClient:
         params = {"days": days}
         resp: requests.Response | None = None
         try:
-            resp = requests.get(url, headers=self.session.headers, params=params)
+            resp = self.session.get(url, headers=self.session.headers, params=params)
             resp.raise_for_status()
             data = resp.json()
             return data.get("search_terms", [])


### PR DESCRIPTION
## Summary
- route WordPress stats queries through the client's session
- patch tests to mock session-level GET requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68987767efc08329ba8a2682d3565b31