### PR TITLE
Handle optional images in WordPress service

### DIFF
--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import List
 
 from wordpress_client import WordpressClient
 
@@ -76,7 +75,7 @@ def build_paid_block(
 def post_to_wordpress(
     title: str,
     content: str,
-    images: List[tuple[Path, str]] = [],
+    images: list[tuple[Path, str]] | None = None,
     account: str | None = None,
     paid_content: str | None = None,
     paid_title: str | None = None,
@@ -93,6 +92,7 @@ def post_to_wordpress(
 
     body = f"<p>{content}</p>"
     featured_id = None
+    images = images or []
     for img_path, filename in images:
         if not img_path.exists():
             return {"error": f"Image file not found: {img_path}"}

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -119,7 +119,6 @@ def test_post_to_wordpress_adds_paid_block(monkeypatch):
     resp = wp_service.post_to_wordpress(
         "T",
         "B",
-        [],
         account="acc",
         paid_content="Secret",
         paid_title="Hidden",
@@ -143,7 +142,6 @@ def test_post_to_wordpress_without_paid_content(monkeypatch):
     resp = wp_service.post_to_wordpress(
         "Title",
         "Body",
-        [],
         account="acc",
     )
     assert resp == {"id": 10, "link": "http://post", "site": "mysite"}
@@ -158,7 +156,6 @@ def test_post_to_wordpress_categories_tags(monkeypatch):
     resp = wp_service.post_to_wordpress(
         "Title",
         "Body",
-        [],
         account="acc",
         categories=["News", "Tech"],
         tags=["python", "fastapi"],


### PR DESCRIPTION
## Summary
- Allow `post_to_wordpress` to accept `None` for the `images` argument and handle it safely
- Adjust WordPress service tests to call `post_to_wordpress` without empty image lists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689879b8ad588329983de8a08080a15a