### PR TITLE
Validate WordPress stats query params

### DIFF
--- a/server.py
+++ b/server.py
@@ -17,7 +17,7 @@ from services.wordpress_stats import (
 import os
 import tempfile
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Query
 from pydantic import BaseModel
 
 CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
@@ -460,12 +460,19 @@ async def wordpress_post(data: WordpressPostRequest):
 
 
 @app.get("/wordpress/stats/views")
-async def wordpress_post_views(post_id: int, days: int, account: str | None = None):
+async def wordpress_post_views(
+    post_id: int = Query(..., gt=0),
+    days: int = Query(..., gt=0, le=30),
+    account: str | None = None,
+):
     return service_get_post_views(account, post_id, days)
 
 
 @app.get("/wordpress/stats/search-terms")
-async def wordpress_search_terms(days: int, account: str | None = None):
+async def wordpress_search_terms(
+    days: int = Query(..., gt=0, le=30),
+    account: str | None = None,
+):
     return service_get_search_terms(account, days)
 
 

--- a/tests/test_wordpress_stats.py
+++ b/tests/test_wordpress_stats.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import sys
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import server
@@ -88,4 +89,24 @@ def test_wordpress_search_terms_endpoint(monkeypatch):
         == "https://public-api.wordpress.com/rest/v1.1/sites/mysite/stats/search-terms"
     )
     assert captured["params"] == {"days": 7}
+
+
+@pytest.mark.parametrize("days", [0, -1])
+def test_wordpress_views_invalid_days(days):
+    app = TestClient(server.app)
+    resp = app.get(
+        "/wordpress/stats/views",
+        params={"post_id": 1, "days": days},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.parametrize("days", [0, -1])
+def test_wordpress_search_terms_invalid_days(days):
+    app = TestClient(server.app)
+    resp = app.get(
+        "/wordpress/stats/search-terms",
+        params={"days": days},
+    )
+    assert resp.status_code == 422
 


### PR DESCRIPTION
## Summary
- enforce positive post IDs and limit stats queries to 1-30 days using FastAPI Query constraints
- add tests ensuring WordPress stats endpoints reject zero or negative day values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68987bf6a5fc832983abf52717a61105