### PR TITLE
Ensure WordPress temp files cleaned on service errors

### DIFF
--- a/server.py
+++ b/server.py
@@ -402,23 +402,25 @@ def post_to_wordpress(
                         pass
                 return {"error": f"Media upload failed: {exc}"}
 
-    result = service_post_to_wordpress(
-        title,
-        content,
-        images,
-        account,
-        paid_content=paid_content,
-        paid_title=paid_title,
-        paid_message=paid_message,
-        plan_id=plan_id,
-        categories=categories,
-        tags=tags,
-    )
-    for p, _ in images:
-        try:
-            os.unlink(p)
-        except Exception:
-            pass
+    try:
+        result = service_post_to_wordpress(
+            title,
+            content,
+            images,
+            account,
+            paid_content=paid_content,
+            paid_title=paid_title,
+            paid_message=paid_message,
+            plan_id=plan_id,
+            categories=categories,
+            tags=tags,
+        )
+    finally:
+        for p, _ in images:
+            try:
+                os.unlink(p)
+            except Exception:
+                pass
     return result
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- guarantee WordPress post temp files are deleted even if the service layer fails
- add regression test for temp file cleanup on service exceptions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68987e662a8c8329b04f87cad0e06d00