### PR TITLE
Use debug logging in client authentication

### DIFF
--- a/note_client.py
+++ b/note_client.py
@@ -1,8 +1,12 @@
 from pathlib import Path
+import logging
 import requests
 
 class NoteAuthError(Exception):
     """Raised when authentication with Note fails."""
+
+
+logger = logging.getLogger(__name__)
 
 
 class NoteClient:
@@ -24,7 +28,9 @@ class NoteClient:
             url, json={"login": username, "password": password}
         )
         self.session.cookies.update(resp.cookies)
-        print(f'Login status: {resp.status_code}, body: {resp.text}')
+        logger.debug(
+            "Login status: %s, body: [redacted]", resp.status_code
+        )
         if resp.status_code not in (200, 201):
             raise NoteAuthError(f"Login failed with status {resp.status_code}")
 

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -1,8 +1,12 @@
+import logging
 import requests
 
 
 class WordpressAuthError(Exception):
     """Raised when authentication with WordPress fails."""
+
+
+logger = logging.getLogger(__name__)
 
 
 class WordpressClient:
@@ -41,7 +45,9 @@ class WordpressClient:
         resp: requests.Response | None = None
         try:
             resp = self.session.post(self.TOKEN_URL, data=data)
-            print(resp.status_code, resp.text)
+            logger.debug(
+                "Auth response status: %s, body: [redacted]", resp.status_code
+            )
             resp.raise_for_status()
             token = resp.json().get("access_token")
             if not token:
@@ -50,7 +56,9 @@ class WordpressClient:
             self.session.headers.update({"Authorization": f"Bearer {token}"})
         except Exception as exc:
             if resp is not None:
-                print(resp.status_code, resp.text)
+                logger.debug(
+                    "Auth failure status: %s, body: [redacted]", resp.status_code
+                )
             raise WordpressAuthError(f"Authentication failed: {exc}") from exc
 
     def upload_media(self, content: bytes, filename: str) -> dict:


### PR DESCRIPTION
## Summary
- replace print statements in WordPress and Note client authentication with debug logging, redacting response bodies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68987f3e64f88329857d92cd8f42bef4