### PR TITLE
Log API requests when posting

### DIFF
--- a/server.py
+++ b/server.py
@@ -17,7 +17,7 @@ from services.wordpress_stats import (
 import os
 import tempfile
 
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, Query, Request
 from pydantic import BaseModel
 
 CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
@@ -32,6 +32,19 @@ else:
 print(json.dumps(CONFIG.get('note', {}), indent=2))
 
 app = FastAPI(title="autoPoster")
+
+
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    """Log incoming API requests with method, path and body."""
+    body = await request.body()
+    try:
+        body_text = body.decode("utf-8")
+    except Exception:
+        body_text = str(body)
+    print(f"{request.method} {request.url.path} {body_text}")
+    response = await call_next(request)
+    return response
 
 
 def validate_mastodon_accounts(config: Dict) -> Dict[str, str]:

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -112,6 +112,7 @@ class WordpressClient:
             payload["tags"] = ",".join(tags)
         resp: requests.Response | None = None
         try:
+            print(f"POST {url} payload: {payload}")
             resp = self.session.post(url, json=payload)
             print(resp.status_code, resp.text)
             resp.raise_for_status()


### PR DESCRIPTION
## Summary
- log incoming HTTP requests with method, path, and body via FastAPI middleware
- print WordPress post payloads before sending to API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68989e2c2c048329ba09be26bae2fda7