### PR TITLE
Add WordPress posts listing endpoint and client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,32 @@ Sample response:
 }
 ```
 
+### `GET /wordpress/posts`
+
+List recent posts on a WordPress.com site.
+
+Query parameters:
+
+- `account`: WordPress account name from `config.json`.
+- `page`: Page number to fetch (default 1).
+- `number`: Number of posts per page (default 10).
+
+Example using `curl`:
+
+```bash
+curl "http://localhost:8765/wordpress/posts?account=account1&page=1&number=5"
+```
+
+Sample response:
+
+```json
+{
+  "posts": [
+    { "id": 1, "title": "Example", "date": "2020-01-01T00:00:00", "url": "http://post" }
+  ]
+}
+```
+
 ### `POST /note/draft`
 
 Create a draft on a configured Note account. Specify the account name in

--- a/server.py
+++ b/server.py
@@ -14,6 +14,7 @@ from services.wordpress_stats import (
     get_post_views as service_get_post_views,
     get_search_terms as service_get_search_terms,
 )
+from services.wordpress_posts import list_posts as service_list_posts
 import os
 import tempfile
 
@@ -459,6 +460,15 @@ async def wordpress_post(data: WordpressPostRequest):
         data.tags,
     )
     return post_info
+
+
+@app.get("/wordpress/posts")
+async def wordpress_posts(
+    page: int = Query(1, gt=0),
+    number: int = Query(10, gt=0),
+    account: str | None = None,
+):
+    return service_list_posts(account, page, number)
 
 
 @app.get("/wordpress/stats/views")

--- a/services/wordpress_posts.py
+++ b/services/wordpress_posts.py
@@ -1,0 +1,13 @@
+from services.post_to_wordpress import create_wp_client, WP_CLIENT
+
+
+def list_posts(account: str | None, page: int, number: int) -> dict:
+    """Retrieve posts from WordPress."""
+    client = WP_CLIENT if account is None else create_wp_client(account)
+    if client is None:
+        return {"error": "WordPress client unavailable"}
+    try:
+        posts = client.list_posts(page=page, number=number)
+    except Exception as exc:
+        return {"error": str(exc)}
+    return {"posts": posts}

--- a/tests/test_wordpress_posts.py
+++ b/tests/test_wordpress_posts.py
@@ -1,0 +1,132 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import server
+import wordpress_client
+import services.wordpress_posts as wp_posts
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+        self.text = "ok"
+        self.headers = {}
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+def test_client_list_posts(monkeypatch):
+    client = wordpress_client.WordpressClient({"wordpress": {"site": "mysite"}})
+    captured = {}
+
+    def fake_get(url, headers=None, params=None):
+        captured["url"] = url
+        captured["params"] = params
+        return DummyResp(
+            {
+                "posts": [
+                    {
+                        "ID": 1,
+                        "title": "T1",
+                        "date": "2020-01-01T00:00:00",
+                        "URL": "http://p1",
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr(client.session, "get", fake_get)
+    posts = client.list_posts(page=2, number=5)
+    assert (
+        captured["url"]
+        == "https://public-api.wordpress.com/rest/v1.1/sites/mysite/posts"
+    )
+    assert captured["params"] == {"page": 2, "number": 5}
+    assert posts == [
+        {
+            "id": 1,
+            "title": "T1",
+            "date": "2020-01-01T00:00:00",
+            "url": "http://p1",
+        }
+    ]
+
+
+def test_wordpress_posts_endpoint(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers=None, params=None):
+        captured["url"] = url
+        captured["params"] = params
+        return DummyResp(
+            {
+                "posts": [
+                    {
+                        "ID": 1,
+                        "title": "T1",
+                        "date": "2020-01-01T00:00:00",
+                        "URL": "http://p1",
+                    }
+                ]
+            }
+        )
+
+    cfg = {"wordpress": {"accounts": {"default": {"site": "mysite"}}}}
+    client = wordpress_client.WordpressClient(cfg)
+    client.access_token = "tok"
+    client.session.headers.update({"Authorization": "Bearer tok"})
+    monkeypatch.setattr(client.session, "get", fake_get)
+
+    monkeypatch.setattr(wp_posts, "WP_CLIENT", client)
+    monkeypatch.setattr(wp_posts, "create_wp_client", lambda account=None: client)
+
+    app = TestClient(server.app)
+    resp = app.get(
+        "/wordpress/posts",
+        params={"account": "acc", "page": 2, "number": 5},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "posts": [
+            {
+                "id": 1,
+                "title": "T1",
+                "date": "2020-01-01T00:00:00",
+                "url": "http://p1",
+            }
+        ]
+    }
+    assert (
+        captured["url"]
+        == "https://public-api.wordpress.com/rest/v1.1/sites/mysite/posts"
+    )
+    assert captured["params"] == {"page": 2, "number": 5}
+
+
+def test_service_list_posts(monkeypatch):
+    class DummyClient:
+        def list_posts(self, page=1, number=10):
+            return [{"id": 1}]
+
+    dummy = DummyClient()
+    monkeypatch.setattr(wp_posts, "WP_CLIENT", dummy)
+    monkeypatch.setattr(wp_posts, "create_wp_client", lambda account=None: dummy)
+    res = wp_posts.list_posts(None, 1, 10)
+    assert res == {"posts": [{"id": 1}]}
+
+
+@pytest.mark.parametrize("page,number", [(0, 1), (1, 0)])
+def test_wordpress_posts_invalid_params(page, number):
+    app = TestClient(server.app)
+    resp = app.get("/wordpress/posts", params={"page": page, "number": number})
+    assert resp.status_code == 422

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -121,6 +121,31 @@ class WordpressClient:
                 print(resp.status_code, resp.text)
             raise RuntimeError(f"Post creation failed: {exc}") from exc
 
+    def list_posts(self, page: int = 1, number: int = 10) -> list[dict]:
+        """Return recent posts with basic information."""
+        url = f"{self.API_BASE.format(site=self.site)}/posts"
+        params = {"page": page, "number": number}
+        resp: requests.Response | None = None
+        try:
+            resp = self.session.get(url, headers=self.session.headers, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+            posts: list[dict] = []
+            for item in data.get("posts", []):
+                posts.append(
+                    {
+                        "id": item.get("ID"),
+                        "title": item.get("title"),
+                        "date": item.get("date"),
+                        "url": item.get("URL"),
+                    }
+                )
+            return posts
+        except Exception as exc:
+            if resp is not None:
+                print(resp.status_code, resp.text)
+            raise RuntimeError(f"Fetching posts failed: {exc}") from exc
+
     def get_post_views(self, post_id: int, days: int) -> dict:
         """Return view statistics for a post over a number of days."""
         url = f"{self.API_BASE.format(site=self.site)}/stats/post/{post_id}"


### PR DESCRIPTION
## Summary
- add `list_posts` to `WordpressClient` to fetch basic post info
- expose `/wordpress/posts` API and service helper
- document and test listing posts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c0a2ae13c8329a7ab7a99523fa396