### PR TITLE
Add WordPress post deletion API

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,34 @@ Sample response:
 }
 ```
 
+### `DELETE /wordpress/posts`
+
+Delete multiple posts on WordPress.com by ID.
+
+Query parameters:
+
+- `account`: WordPress account name from `config.json`.
+- `ids`: One or more post IDs to delete. Specify `ids` multiple times in the query string.
+
+Example using `curl`:
+
+```bash
+curl -X DELETE "http://localhost:8765/wordpress/posts?account=account1&ids=1&ids=2"
+```
+
+Sample response:
+
+```json
+{
+  "deleted": [1, 2],
+  "errors": {},
+  "success": 2,
+  "failed": 0
+}
+```
+
+If an individual deletion fails, the `errors` object maps the post ID to an error message and the `failed` count is incremented.
+
 ### `POST /note/draft`
 
 Create a draft on a configured Note account. Specify the account name in

--- a/server.py
+++ b/server.py
@@ -14,7 +14,10 @@ from services.wordpress_stats import (
     get_post_views as service_get_post_views,
     get_search_terms as service_get_search_terms,
 )
-from services.wordpress_posts import list_posts as service_list_posts
+from services.wordpress_posts import (
+    list_posts as service_list_posts,
+    delete_posts as service_delete_posts,
+)
 import os
 import tempfile
 
@@ -482,6 +485,17 @@ async def wordpress_posts(
     account: str | None = None,
 ):
     return service_list_posts(account, page, number)
+
+
+@app.delete("/wordpress/posts")
+async def wordpress_delete_posts(
+    ids: List[int] = Query(...),
+    account: str | None = None,
+):
+    result = service_delete_posts(account, ids)
+    success = len(result.get("deleted", []))
+    failed = len(result.get("errors", {}))
+    return {**result, "success": success, "failed": failed}
 
 
 @app.get("/wordpress/stats/views")

--- a/services/wordpress_posts.py
+++ b/services/wordpress_posts.py
@@ -11,3 +11,21 @@ def list_posts(account: str | None, page: int, number: int) -> dict:
     except Exception as exc:
         return {"error": str(exc)}
     return {"posts": posts}
+
+
+def delete_posts(account: str | None, ids: list[int]) -> dict:
+    """Delete multiple WordPress posts and report successes and failures."""
+    client = WP_CLIENT if account is None else create_wp_client(account)
+    if client is None:
+        return {"error": "WordPress client unavailable"}
+
+    deleted: list[int] = []
+    errors: dict[str, str] = {}
+    for pid in ids:
+        try:
+            deleted_id = client.delete_post(pid)
+            deleted.append(deleted_id)
+        except Exception as exc:
+            errors[str(pid)] = str(exc)
+
+    return {"deleted": deleted, "errors": errors}

--- a/tests/test_wordpress_posts_delete.py
+++ b/tests/test_wordpress_posts_delete.py
@@ -1,0 +1,83 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import server
+import wordpress_client
+import services.wordpress_posts as wp_posts
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+        self.text = "ok"
+        self.headers = {}
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+def test_client_delete_post(monkeypatch):
+    client = wordpress_client.WordpressClient({"wordpress": {"site": "mysite"}})
+    captured = {}
+
+    def fake_post(url):
+        captured["url"] = url
+        return DummyResp({"ID": 5})
+
+    monkeypatch.setattr(client.session, "post", fake_post)
+    deleted = client.delete_post(5)
+    assert (
+        captured["url"]
+        == "https://public-api.wordpress.com/rest/v1.1/sites/mysite/posts/5/delete"
+    )
+    assert deleted == 5
+
+
+def test_service_delete_posts(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.called = []
+
+        def delete_post(self, pid):
+            if pid == 2:
+                raise RuntimeError("nope")
+            self.called.append(pid)
+            return pid
+
+    dummy = DummyClient()
+    monkeypatch.setattr(wp_posts, "WP_CLIENT", dummy)
+    monkeypatch.setattr(wp_posts, "create_wp_client", lambda account=None: dummy)
+
+    res = wp_posts.delete_posts(None, [1, 2, 3])
+    assert res == {"deleted": [1, 3], "errors": {"2": "nope"}}
+    assert dummy.called == [1, 3]
+
+
+def test_delete_posts_endpoint(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.deleted = []
+
+        def delete_post(self, pid):
+            self.deleted.append(pid)
+            return pid
+
+    dummy = DummyClient()
+    monkeypatch.setattr(wp_posts, "WP_CLIENT", dummy)
+    monkeypatch.setattr(wp_posts, "create_wp_client", lambda account=None: dummy)
+
+    app = TestClient(server.app)
+    resp = app.delete(
+        "/wordpress/posts", params=[("ids", "1"), ("ids", "2"), ("account", "acc")]
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"deleted": [1, 2], "errors": {}, "success": 2, "failed": 0}
+    assert dummy.deleted == [1, 2]

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -147,6 +147,19 @@ class WordpressClient:
                 print(resp.status_code, resp.text)
             raise RuntimeError(f"Fetching posts failed: {exc}") from exc
 
+    def delete_post(self, post_id: int) -> int:
+        """Delete a post by ID and return the deleted ID."""
+        url = f"{self.API_BASE.format(site=self.site)}/posts/{post_id}/delete"
+        resp: requests.Response | None = None
+        try:
+            resp = self.session.post(url)
+            resp.raise_for_status()
+            return post_id
+        except Exception as exc:
+            if resp is not None:
+                print(resp.status_code, resp.text)
+            raise RuntimeError(f"Post deletion failed: {exc}") from exc
+
     def get_post_views(self, post_id: int, days: int) -> dict:
         """Return view statistics for a post over a number of days."""
         url = f"{self.API_BASE.format(site=self.site)}/stats/post/{post_id}"


### PR DESCRIPTION
## Summary
- add `WordpressClient.delete_post` for WordPress.com REST API
- implement service and FastAPI endpoint to delete multiple posts
- document and test bulk deletion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c0b7a12c48329a89c5ff96126b839