### PR TITLE
Return WordPress post link and update tests

### DIFF
--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -133,5 +133,8 @@ def post_to_wordpress(
         )
     except Exception as exc:
         return {"error": str(exc)}
-    post_info = {**post_info, "site": client.site}
-    return post_info
+    return {
+        "id": post_info.get("id"),
+        "link": post_info.get("link"),
+        "site": client.site,
+    }

--- a/tests/test_wordpress_client.py
+++ b/tests/test_wordpress_client.py
@@ -80,3 +80,25 @@ def test_get_search_terms_parses_views(monkeypatch):
         {"term": "foo", "views": 5},
         {"term": "bar", "views": 1},
     ]
+
+
+def test_create_post_returns_link(monkeypatch):
+    client = _make_client()
+
+    def fake_post(url, json):
+        return DummyResp({"ID": 7, "URL": "http://example/post"})
+
+    monkeypatch.setattr(client.session, "post", fake_post)
+    res = client.create_post("T", "<p>B</p>")
+    assert res == {"id": 7, "link": "http://example/post"}
+
+
+def test_create_post_fallback_link(monkeypatch):
+    client = _make_client()
+
+    def fake_post(url, json):
+        return DummyResp({"ID": 8, "link": "http://example/alt"})
+
+    monkeypatch.setattr(client.session, "post", fake_post)
+    res = client.create_post("T", "<p>B</p>")
+    assert res == {"id": 8, "link": "http://example/alt"}

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -37,7 +37,7 @@ def make_client(monkeypatch, config):
             return DummyResponse({"media": [{"id": 1, "source_url": "http://img"}]})
         if url.endswith("/posts/new"):
             calls["post"] = kwargs.get("json")
-            return DummyResponse({"id": 10, "link": "http://post"})
+            return DummyResponse({"ID": 10, "URL": "http://post"})
         raise AssertionError(f"Unexpected URL {url}")
 
     monkeypatch.setattr(requests, "post", fake_post)

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -87,7 +87,9 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
         paid_message="Msg",
         plan_id="p1",
     )
-    assert resp == {"id": 10, "link": "http://post", "site": "mysite"}
+    assert resp["id"] == 10
+    assert resp["link"] == "http://post"
+    assert resp["site"] == "mysite"
     # Uploaded both images
     assert dummy.uploaded[0][0] == "x1.jpg"
     assert dummy.uploaded[1][0] == "x2.jpg"
@@ -124,7 +126,9 @@ def test_post_to_wordpress_adds_paid_block(monkeypatch):
         paid_title="Hidden",
         paid_message="M",
     )
-    assert resp == {"id": 10, "link": "http://post", "site": "mysite"}
+    assert resp["id"] == 10
+    assert resp["link"] == "http://post"
+    assert resp["site"] == "mysite"
     assert "wp:jetpack/subscribers-only-content" in dummy.created["html"]
     assert "<h2>Hidden</h2>" in dummy.created["html"]
     assert "<p>Secret</p>" in dummy.created["html"]
@@ -144,7 +148,9 @@ def test_post_to_wordpress_without_paid_content(monkeypatch):
         "Body",
         account="acc",
     )
-    assert resp == {"id": 10, "link": "http://post", "site": "mysite"}
+    assert resp["id"] == 10
+    assert resp["link"] == "http://post"
+    assert resp["site"] == "mysite"
     assert "wp:jetpack/subscribers-only-content" not in dummy.created["html"]
     assert dummy.created["paid_content"] is None
 
@@ -160,6 +166,8 @@ def test_post_to_wordpress_categories_tags(monkeypatch):
         categories=["News", "Tech"],
         tags=["python", "fastapi"],
     )
-    assert resp == {"id": 10, "link": "http://post", "site": "mysite"}
+    assert resp["id"] == 10
+    assert resp["link"] == "http://post"
+    assert resp["site"] == "mysite"
     assert dummy.created["categories"] == ["News", "Tech"]
     assert dummy.created["tags"] == ["python", "fastapi"]

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -116,7 +116,11 @@ class WordpressClient:
             resp = self.session.post(url, json=payload)
             print(resp.status_code, resp.text)
             resp.raise_for_status()
-            return resp.json()
+            data = resp.json()
+            return {
+                "id": data.get("ID"),
+                "link": data.get("URL") or data.get("link"),
+            }
         except Exception as exc:
             if resp is not None:
                 print(resp.status_code, resp.text)


### PR DESCRIPTION
## Summary
- Parse `WordpressClient.create_post` responses and return only the post ID and permalink
- Preserve `link` when adding `site` in `post_to_wordpress`
- Update tests to validate presence of `link`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c1084195c8329bede371687ebcfb5