### PR TITLE
Normalize post responses and add integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ A simple REST API that receives post requests and forwards them to various servi
 
 ## API
 
+All endpoints that publish content return a JSON object in the following format on success:
+
+```json
+{ "id": 1, "link": "https://example.com/post/1", "site": "service" }
+```
+
 ### `POST /post`
 
 Send JSON with the following structure:
@@ -144,6 +150,12 @@ curl -X POST http://localhost:8765/mastodon/post \
      -d '{"account": "account1", "text": "Hello world", "media": ["b64"]}'
 ```
 
+Sample response:
+
+```json
+{ "id": 1, "link": "https://mastodon.example/@user/1", "site": "mastodon" }
+```
+
 ### `POST /twitter/post`
 
 Send a tweet from one of the configured Twitter accounts. The JSON payload must
@@ -170,6 +182,12 @@ Example using `curl`:
          -H 'Content-Type: application/json' \
          -d '{"account": "account1", "text": "Hello Twitter", "media": ["b64"]}'
   ```
+
+Sample response:
+
+```json
+{ "id": "123", "link": "https://twitter.com/user/status/123", "site": "twitter" }
+```
 
 ### `POST /wordpress/post`
 
@@ -239,11 +257,11 @@ Sample response:
 {
   "id": 10,
   "link": "http://post",
-  "site": "your-site.wordpress.com"
+  "site": "wordpress"
 }
 ```
 
-Clients should store the `{site, id}` pair for Stats API calls.
+All services respond using this common `{id, link, site}` format.
 
 If the site does not have a plan that supports Premium Content, WordPress.com
 returns an error and the API responds with a message such as `{"error":
@@ -373,6 +391,12 @@ Example using `curl`:
 curl -X POST http://localhost:8765/note/draft \
      -H 'Content-Type: application/json' \
      -d '{"account": "default", "content": "Hello Note", "images": ["example/test.png"]}'
+```
+
+Sample response:
+
+```json
+{ "id": 5, "link": "https://note.com/.../draft", "site": "note" }
 ```
 
 ## Troubleshooting

--- a/server.py
+++ b/server.py
@@ -349,7 +349,11 @@ def post_to_mastodon(account: str, text: str, media: Optional[List[str]] = None)
     except Exception as exc:
         return {"error": str(exc)}
 
-    return {"posted": True, "url": status["url"]}
+    return {
+        "id": status.get("id"),
+        "link": status.get("url"),
+        "site": "mastodon",
+    }
 
 
 def post_to_twitter(account: str, text: str, media: Optional[List[str]] = None):
@@ -389,8 +393,16 @@ def post_to_twitter(account: str, text: str, media: Optional[List[str]] = None):
     except Exception:
         username = ""
 
-    url = f"https://twitter.com/{username}/status/{tweet_id}" if tweet_id and username else None
-    return {"posted": True, "url": url}
+    url = (
+        f"https://twitter.com/{username}/status/{tweet_id}"
+        if tweet_id and username
+        else None
+    )
+    return {
+        "id": tweet_id,
+        "link": url,
+        "site": "twitter",
+    }
 
 
 def post_to_wordpress(

--- a/services/post_to_note.py
+++ b/services/post_to_note.py
@@ -71,4 +71,8 @@ def post_to_note(content: str, images: List[Path] = [], account: str | None = No
     except Exception as exc:
         return {"error": str(exc)}
 
-    return draft_info
+    return {
+        "id": draft_info.get("note_id"),
+        "link": draft_info.get("draft_url"),
+        "site": "note",
+    }

--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -136,5 +136,5 @@ def post_to_wordpress(
     return {
         "id": post_info.get("id"),
         "link": post_info.get("link"),
-        "site": client.site,
+        "site": "wordpress",
     }

--- a/test_mastodon_post.py
+++ b/test_mastodon_post.py
@@ -72,8 +72,9 @@ def test_post_text(monkeypatch, temp_config):
     resp = client.post('/mastodon/post', json={'account': 'acc', 'text': 'hello'})
     assert resp.status_code == 200
     assert resp.json() == {
-        'posted': True,
-        'url': 'https://mastodon.social/@user/1'
+        'id': 1,
+        'link': 'https://mastodon.social/@user/1',
+        'site': 'mastodon'
     }
     assert dummy.posts[0]['text'] == 'hello'
     assert dummy.posts[0]['media_ids'] is None
@@ -86,7 +87,11 @@ def test_post_with_media(monkeypatch, temp_config):
     encoded = base64.b64encode(data).decode()
     resp = client.post('/mastodon/post', json={'account': 'acc', 'text': 'hi', 'media': [encoded]})
     assert resp.status_code == 200
-    assert 'url' in resp.json()
+    assert resp.json() == {
+        'id': 1,
+        'link': 'https://mastodon.social/@user/1',
+        'site': 'mastodon'
+    }
     assert dummy.posts[0]['text'] == 'hi'
     assert isinstance(dummy.media[0], BytesIO)
     assert dummy.media[0].read() == data

--- a/test_twitter_post.py
+++ b/test_twitter_post.py
@@ -92,8 +92,9 @@ def test_post_text(monkeypatch, tw_temp_config):
     resp = client.post('/twitter/post', json={'account': 'acc', 'text': 'hello'})
     assert resp.status_code == 200
     assert resp.json() == {
-        'posted': True,
-        'url': 'https://twitter.com/dummyuser/status/1'
+        'id': '1',
+        'link': 'https://twitter.com/dummyuser/status/1',
+        'site': 'twitter'
     }
     assert dummy_client.tweets[0]['text'] == 'hello'
     assert dummy_client.tweets[0]['media_ids'] is None
@@ -112,7 +113,11 @@ def test_post_with_media(monkeypatch, tw_temp_config):
     encoded = base64.b64encode(data).decode()
     resp = client.post('/twitter/post', json={'account': 'acc', 'text': 'hi', 'media': [encoded]})
     assert resp.status_code == 200
-    assert 'url' in resp.json()
+    assert resp.json() == {
+        'id': '1',
+        'link': 'https://twitter.com/dummyuser/status/1',
+        'site': 'twitter'
+    }
     assert dummy_client.tweets[0]['text'] == 'hi'
     assert isinstance(dummy_api.media[0], BytesIO)
     assert dummy_api.media[0].read() == data

--- a/tests/test_post_format.py
+++ b/tests/test_post_format.py
@@ -1,0 +1,86 @@
+from fastapi.testclient import TestClient
+import server
+
+
+def test_endpoints_return_common_format(monkeypatch):
+    # Mastodon stub
+    class DummyMasto:
+        def status_post(self, text, media_ids=None):
+            return {"id": 1, "url": "http://masto/1"}
+
+        def media_post(self, *args, **kwargs):
+            return {"id": "m1"}
+
+    monkeypatch.setattr(server, "MASTODON_ACCOUNT_ERRORS", {}, raising=False)
+    monkeypatch.setattr(server, "MASTODON_CLIENTS", {"acc": DummyMasto()}, raising=False)
+
+    # Twitter stub
+    class DummyAPI:
+        def media_upload(self, filename, file):
+            return type("M", (), {"media_id": "m1"})
+
+        def verify_credentials(self):
+            return type("U", (), {"screen_name": "user"})()
+
+    class DummyClient:
+        def create_tweet(self, text, media_ids=None):
+            return type("Resp", (), {"data": {"id": "2"}})()
+
+    monkeypatch.setattr(server, "TWITTER_ACCOUNT_ERRORS", {}, raising=False)
+    monkeypatch.setattr(
+        server,
+        "TWITTER_CLIENTS",
+        {"acc": {"client": DummyClient(), "api": DummyAPI()}},
+        raising=False,
+    )
+
+    # WordPress stub
+    monkeypatch.setattr(server, "WORDPRESS_ACCOUNT_ERRORS", {}, raising=False)
+    monkeypatch.setattr(server, "WORDPRESS_CLIENTS", {"acc": object()}, raising=False)
+
+    def fake_wp_post(
+        account,
+        title,
+        content,
+        media=None,
+        paid_content=None,
+        paid_title=None,
+        paid_message=None,
+        plan_id=None,
+        categories=None,
+        tags=None,
+    ):
+        return {"id": 3, "link": "http://wp/3", "site": "wordpress"}
+
+    monkeypatch.setattr(server, "service_post_to_wordpress", fake_wp_post)
+
+    # Note stub
+    def fake_post_to_note(content, images=None, account=None):
+        return {"id": 4, "link": "http://note/4", "site": "note"}
+
+    monkeypatch.setattr(server, "post_to_note", fake_post_to_note)
+
+    client = TestClient(server.app)
+
+    r1 = client.post("/mastodon/post", json={"account": "acc", "text": "hi"})
+    assert r1.status_code == 200
+    assert r1.json() == {"id": 1, "link": "http://masto/1", "site": "mastodon"}
+
+    r2 = client.post("/twitter/post", json={"account": "acc", "text": "hi"})
+    assert r2.status_code == 200
+    assert r2.json() == {
+        "id": "2",
+        "link": "https://twitter.com/user/status/2",
+        "site": "twitter",
+    }
+
+    r3 = client.post(
+        "/wordpress/post",
+        json={"account": "acc", "title": "T", "content": "C"},
+    )
+    assert r3.status_code == 200
+    assert r3.json() == {"id": 3, "link": "http://wp/3", "site": "wordpress"}
+
+    r4 = client.post("/note/draft", json={"account": "acc", "content": "C"})
+    assert r4.status_code == 200
+    assert r4.json() == {"id": 4, "link": "http://note/4", "site": "note"}

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -90,7 +90,7 @@ def test_wordpress_post_success(monkeypatch):
         },
     )
     assert resp.status_code == 200
-    assert resp.json() == {"id": 10, "link": "http://post", "site": "mysite"}
+    assert resp.json() == {"id": 10, "link": "http://post", "site": "wordpress"}
     assert len(calls["uploads"]) == 1
     filename, content = calls["uploads"][0]
     assert filename == "img.png"

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -89,7 +89,7 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     )
     assert resp["id"] == 10
     assert resp["link"] == "http://post"
-    assert resp["site"] == "mysite"
+    assert resp["site"] == "wordpress"
     # Uploaded both images
     assert dummy.uploaded[0][0] == "x1.jpg"
     assert dummy.uploaded[1][0] == "x2.jpg"
@@ -128,7 +128,7 @@ def test_post_to_wordpress_adds_paid_block(monkeypatch):
     )
     assert resp["id"] == 10
     assert resp["link"] == "http://post"
-    assert resp["site"] == "mysite"
+    assert resp["site"] == "wordpress"
     assert "wp:jetpack/subscribers-only-content" in dummy.created["html"]
     assert "<h2>Hidden</h2>" in dummy.created["html"]
     assert "<p>Secret</p>" in dummy.created["html"]
@@ -150,7 +150,7 @@ def test_post_to_wordpress_without_paid_content(monkeypatch):
     )
     assert resp["id"] == 10
     assert resp["link"] == "http://post"
-    assert resp["site"] == "mysite"
+    assert resp["site"] == "wordpress"
     assert "wp:jetpack/subscribers-only-content" not in dummy.created["html"]
     assert dummy.created["paid_content"] is None
 
@@ -168,6 +168,6 @@ def test_post_to_wordpress_categories_tags(monkeypatch):
     )
     assert resp["id"] == 10
     assert resp["link"] == "http://post"
-    assert resp["site"] == "mysite"
+    assert resp["site"] == "wordpress"
     assert dummy.created["categories"] == ["News", "Tech"]
     assert dummy.created["tags"] == ["python", "fastapi"]


### PR DESCRIPTION
## Summary
- unify post functions for Mastodon, Twitter, WordPress and Note to return `{id, link, site}`
- document the common response format in README
- add integration test validating consistent responses

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c15340f008329826e7c3de11f7818