### PR TITLE
Add WordPress trash purging utility

### DIFF
--- a/cleanup_wordpress_posts.py
+++ b/cleanup_wordpress_posts.py
@@ -72,6 +72,11 @@ def main() -> None:
         except Exception as exc:  # pragma: no cover
             print(f"Failed to delete post {p['id']}: {exc}")
 
+    answer = input("Empty trash permanently? [y/N] ").strip().lower()
+    if answer == "y":
+        deleted = client.empty_trash()
+        print(f"Emptied trash, removed {len(deleted)} posts")
+
     print("Cleanup complete")
 
 

--- a/tests/test_wordpress_posts.py
+++ b/tests/test_wordpress_posts.py
@@ -62,6 +62,19 @@ def test_client_list_posts(monkeypatch):
     ]
 
 
+def test_client_list_posts_status(monkeypatch):
+    client = wordpress_client.WordpressClient({"wordpress": {"site": "mysite"}})
+    captured = {}
+
+    def fake_get(url, headers=None, params=None):
+        captured["params"] = params
+        return DummyResp({"posts": []})
+
+    monkeypatch.setattr(client.session, "get", fake_get)
+    client.list_posts(status="trash")
+    assert captured["params"] == {"page": 1, "number": 10, "status": "trash"}
+
+
 def test_wordpress_posts_endpoint(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary
- allow listing posts by status and permanently deleting posts
- add method to permanently empty the WordPress trash
- extend cleanup helper to optionally purge trash

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c1d8052048329819cc519de337b3b