### PR TITLE
Add media alt text update support

### DIFF
--- a/tests/test_wordpress_client.py
+++ b/tests/test_wordpress_client.py
@@ -133,3 +133,15 @@ def test_list_media_and_delete(monkeypatch):
     assert media == [{"ID": 1}]
     deleted = client.delete_media(1)
     assert deleted == 1
+
+def test_update_media_alt_text(monkeypatch):
+    client = _make_client()
+
+    def fake_post(url, json):
+        assert url.endswith("/media/5")
+        assert json == {"alt_text": "New alt"}
+        return DummyResp({"id": 5, "alt_text": "New alt"})
+
+    monkeypatch.setattr(client.session, "post", fake_post)
+    res = client.update_media_alt_text(5, "New alt")
+    assert res == {"id": 5, "alt_text": "New alt"}

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -263,6 +263,22 @@ class WordpressClient:
                 print(resp.status_code, resp.text)
             raise RuntimeError(f"Fetching media failed: {exc}") from exc
 
+    def update_media_alt_text(self, media_id: int, alt_text: str) -> dict:
+        """Update the alt text for a media item."""
+        url = f"{self.API_BASE.format(site=self.site)}/media/{media_id}"
+        payload = {"alt_text": alt_text}
+        resp: requests.Response | None = None
+        try:
+            resp = self.session.post(url, json=payload)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            if resp is not None:
+                print(resp.status_code, resp.text)
+            raise RuntimeError(
+                f"Updating media alt text failed: {exc}"
+            ) from exc
+
     def delete_media(self, media_id: int) -> int:
         """Delete a media item by ID and return the deleted ID."""
         url = f"{self.API_BASE.format(site=self.site)}/media/{media_id}/delete"


### PR DESCRIPTION
## Summary
- add `update_media_alt_text` to `WordpressClient`
- test updating media alt text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689da197871c83298d8e982ca186eed7