### PR TITLE
Add alt text support for WordPress media uploads

### DIFF
--- a/server.py
+++ b/server.py
@@ -311,6 +311,7 @@ class NotePostRequest(BaseModel):
 class WordpressMediaItem(BaseModel):
     filename: str
     data: str
+    alt: Optional[str] = None
 
 
 class WordpressPostRequest(BaseModel):
@@ -423,7 +424,7 @@ def post_to_wordpress(
     if not client:
         return {"error": "Account not configured"}
 
-    images: List[tuple[Path, str]] = []
+    images: List[tuple[Path, str, Optional[str]]] = []
     if media:
         for item in media:
             try:
@@ -434,9 +435,9 @@ def post_to_wordpress(
                 tmp.write(data)
                 tmp.flush()
                 tmp.close()
-                images.append((Path(tmp.name), item.filename))
+                images.append((Path(tmp.name), item.filename, item.alt))
             except Exception as exc:
-                for p, _ in images:
+                for p, _, _ in images:
                     try:
                         os.unlink(p)
                     except Exception:
@@ -457,7 +458,7 @@ def post_to_wordpress(
             tags=tags,
         )
     finally:
-        for p, _ in images:
+        for p, _, _ in images:
             try:
                 os.unlink(p)
             except Exception:

--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -78,7 +78,7 @@ def build_paid_block(
 def post_to_wordpress(
     title: str,
     content: str,
-    images: list[tuple[Path, str]] | None = None,
+    images: list[tuple[Path, str, str | None]] | None = None,
     account: str | None = None,
     paid_content: str | None = None,
     paid_title: str | None = None,
@@ -96,7 +96,12 @@ def post_to_wordpress(
     body = f"<p>{content}</p>"
     featured_id = None
     images = images or []
-    for img_path, filename in images:
+    for item in images:
+        if len(item) == 3:
+            img_path, filename, alt = item
+        else:
+            img_path, filename = item  # type: ignore[misc]
+            alt = None
         if not img_path.exists():
             return {"error": f"Image file not found: {img_path}"}
         try:
@@ -113,7 +118,7 @@ def post_to_wordpress(
         if not url:
             print(f"No URL returned for {img_path}, skipping image tag")
             continue
-        alt_text = uploaded.get("alt") or uploaded.get("title") or Path(filename).stem
+        alt_text = alt or uploaded.get("alt") or uploaded.get("title") or Path(filename).stem
         media_id = uploaded.get("id")
         try:
             if media_id is not None:

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -85,7 +85,7 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     resp = wp_service.post_to_wordpress(
         "Title",
         "Body",
-        [(img1, "x1.jpg"), (img2, "x2.jpg")],
+        [(img1, "x1.jpg", "alt1"), (img2, "x2.jpg", "alt2")],
         account="acc",
         paid_content="Paid",
         paid_title="PTitle",
@@ -99,11 +99,11 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     assert dummy.uploaded[0][0] == "x1.jpg"
     assert dummy.uploaded[1][0] == "x2.jpg"
     # Alt text updated for each image
-    assert dummy.updated_alt_text == [(1, "x1"), (2, "x2")]
+    assert dummy.updated_alt_text == [(1, "alt1"), (2, "alt2")]
     # HTML contains image tags
     html = dummy.created["html"]
-    assert '<img src="http://img1" alt="x1"' in html
-    assert '<img src="http://img2" alt="x2"' in html
+    assert '<img src="http://img1" alt="alt1"' in html
+    assert '<img src="http://img2" alt="alt2"' in html
     # Ensure images have either inline style or wp-block-image class
     markers = html.count('style="max-width:100%;height:auto;"') + html.count(
         "wp-block-image"
@@ -195,7 +195,7 @@ def test_post_to_wordpress_skips_image_without_url(monkeypatch, tmp_path):
     img.write_bytes(b"123")
 
     resp = wp_service.post_to_wordpress(
-        "Title", "Body", [(img, "x.jpg")], account="acc"
+        "Title", "Body", [(img, "x.jpg", "alt")], account="acc"
     )
 
     assert resp["id"] == 10
@@ -218,11 +218,11 @@ def test_post_to_wordpress_warns_on_alt_update_failure(monkeypatch, tmp_path, ca
 
     with caplog.at_level("WARNING"):
         resp = wp_service.post_to_wordpress(
-            "Title", "Body", [(img, "x.jpg")], account="acc"
+            "Title", "Body", [(img, "x.jpg", "custom")], account="acc"
         )
     assert resp["id"] == 10
     assert resp["link"] == "http://post"
     assert "Failed to update alt text" in caplog.text
     # Alt text still used in HTML
     html = dummy.created["html"]
-    assert '<img src="http://img1" alt="x"' in html
+    assert '<img src="http://img1" alt="custom"' in html


### PR DESCRIPTION
## Summary
- allow media items to specify optional alt text when posting to WordPress
- propagate alt text to WordPress service to update media and HTML
- test coverage for alt text handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689da384391483298cd7c67386942918