### PR TITLE
Add tests for WordPress media alt text handling

### DIFF
--- a/tests/test_wordpress_client.py
+++ b/tests/test_wordpress_client.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from wordpress_client import WordpressClient
@@ -145,3 +147,14 @@ def test_update_media_alt_text(monkeypatch):
     monkeypatch.setattr(client.session, "post", fake_post)
     res = client.update_media_alt_text(5, "New alt")
     assert res == {"id": 5, "alt_text": "New alt"}
+
+
+def test_update_media_alt_text_error(monkeypatch):
+    client = _make_client()
+
+    def fake_post(url, json):
+        raise Exception("fail")
+
+    monkeypatch.setattr(client.session, "post", fake_post)
+    with pytest.raises(RuntimeError):
+        client.update_media_alt_text(5, "alt")

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -121,6 +121,19 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     assert dummy.created["paid_content"] is None
 
 
+def test_post_to_wordpress_calls_update_media_alt_text(monkeypatch, tmp_path):
+    dummy = DummyClient({})
+    monkeypatch.setattr(wp_service, "create_wp_client", lambda account=None: dummy)
+
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"123")
+
+    wp_service.post_to_wordpress(
+        "Title", "Body", [(img, "x.jpg", "custom alt")], account="acc"
+    )
+    assert dummy.updated_alt_text == [(1, "custom alt")]
+
+
 def test_post_to_wordpress_adds_paid_block(monkeypatch):
     dummy = DummyClient({"wordpress": {"accounts": {"default": {"plan_id": "cfg"}}}})
     monkeypatch.setattr(wp_service, "create_wp_client", lambda account=None: dummy)


### PR DESCRIPTION
## Summary
- add unit test for `update_media_alt_text` failure case in `WordpressClient`
- ensure WordPress service calls alt text update API when uploading images

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689da4c0675c83298cc8736279425b80