### PR TITLE
Add slug support for WordPress posts

### DIFF
--- a/server.py
+++ b/server.py
@@ -318,6 +318,7 @@ class WordpressPostRequest(BaseModel):
     account: str
     title: str
     content: str
+    slug: Optional[str] = None
     media: Optional[List[WordpressMediaItem]] = None
     paid_content: Optional[str] = None
     paid_title: Optional[str] = None
@@ -410,6 +411,7 @@ def post_to_wordpress(
     account: str,
     title: str,
     content: str,
+    slug: Optional[str] = None,
     media: Optional[List[WordpressMediaItem]] = None,
     paid_content: Optional[str] = None,
     paid_title: Optional[str] = None,
@@ -456,6 +458,7 @@ def post_to_wordpress(
             plan_id=plan_id,
             categories=categories,
             tags=tags,
+            slug=slug,
         )
     finally:
         for p, _, _ in images:
@@ -492,13 +495,14 @@ async def wordpress_post(data: WordpressPostRequest):
         data.account,
         data.title,
         data.content,
-        data.media,
-        data.paid_content,
-        data.paid_title,
-        data.paid_message,
-        data.plan_id,
-        data.categories,
-        data.tags,
+        slug=data.slug,
+        media=data.media,
+        paid_content=data.paid_content,
+        paid_title=data.paid_title,
+        paid_message=data.paid_message,
+        plan_id=data.plan_id,
+        categories=data.categories,
+        tags=data.tags,
     )
     return post_info
 

--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -86,6 +86,7 @@ def post_to_wordpress(
     plan_id: str | None = None,
     categories: list[str] | None = None,
     tags: list[str] | None = None,
+    slug: str | None = None,
 ) -> dict:
     """Create a WordPress post with optional images."""
     client = WP_CLIENT if account is None else create_wp_client(account)
@@ -146,6 +147,7 @@ def post_to_wordpress(
             featured_id,
             categories=categories,
             tags=tags,
+            slug=slug,
         )
     except Exception as exc:
         return {"error": str(exc)}

--- a/tests/test_post_format.py
+++ b/tests/test_post_format.py
@@ -39,16 +39,17 @@ def test_endpoints_return_common_format(monkeypatch):
     monkeypatch.setattr(server, "WORDPRESS_CLIENTS", {"acc": object()}, raising=False)
 
     def fake_wp_post(
-        account,
         title,
         content,
-        media=None,
+        images=None,
+        account=None,
         paid_content=None,
         paid_title=None,
         paid_message=None,
         plan_id=None,
         categories=None,
         tags=None,
+        slug=None,
     ):
         return {"id": 3, "link": "http://wp/3", "site": "wordpress"}
 

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -85,6 +85,7 @@ def test_wordpress_post_success(monkeypatch):
             "account": "acc",
             "title": "T",
             "content": "C",
+            "slug": "my-slug",
             "media": [{"filename": "img.png", "data": encoded, "alt": "ALT"}],
             "paid_content": "Paid",
             "paid_title": "PT",
@@ -104,6 +105,7 @@ def test_wordpress_post_success(monkeypatch):
     assert calls["alt_updates"][0]["alt_text"] == "ALT"
     assert 'alt="ALT"' in payload["content"]
     assert payload["title"] == "T"
+    assert payload["slug"] == "my-slug"
     assert "wp:jetpack/subscribers-only-content" in payload["content"]
     assert "<h2>PT</h2>" in payload["content"]
     assert "<p>Paid</p>" in payload["content"]

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -36,6 +36,7 @@ class DummyClient:
         paid_content=None,
         categories=None,
         tags=None,
+        slug=None,
     ):
         self.created = {
             "title": title,
@@ -44,6 +45,7 @@ class DummyClient:
             "paid_content": paid_content,
             "categories": categories,
             "tags": tags,
+            "slug": slug,
         }
         return {"id": 10, "link": "http://post"}
 
@@ -91,6 +93,7 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
         paid_title="PTitle",
         paid_message="Msg",
         plan_id="p1",
+        slug="slug-post",
     )
     assert resp["id"] == 10
     assert resp["link"] == "http://post"
@@ -111,6 +114,7 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     assert markers >= 2
     # First image used as featured
     assert dummy.created["featured_id"] == 1
+    assert dummy.created["slug"] == "slug-post"
     # Paid content added as subscribers-only block in HTML and not sent separately
     assert "wp:jetpack/subscribers-only-content" in dummy.created["html"]
     assert "<h2>PTitle</h2>" in dummy.created["html"]

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -98,6 +98,7 @@ class WordpressClient:
         paid_content: str | None = None,
         categories: list[str] | None = None,
         tags: list[str] | None = None,
+        slug: str | None = None,
     ) -> dict:
         """Create and publish a post with optional featured image."""
         url = f"{self.API_BASE.format(site=self.site)}/posts/new"
@@ -110,6 +111,8 @@ class WordpressClient:
             payload["categories"] = ",".join(categories)
         if tags:
             payload["tags"] = ",".join(tags)
+        if slug:
+            payload["slug"] = slug
         resp: requests.Response | None = None
         try:
             print(f"POST {url} payload: {payload}")


### PR DESCRIPTION
## Summary
- allow slug in API request for WordPress posts
- propagate slug through service layer and WordPress client payload
- test slug handling in WordPress posting helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689da5d08a3c8329b8f229b978ffd850