### PR TITLE
Add excerpt field to WordPress post flow

### DIFF
--- a/server.py
+++ b/server.py
@@ -319,6 +319,7 @@ class WordpressPostRequest(BaseModel):
     title: str
     content: str
     slug: Optional[str] = None
+    excerpt: Optional[str] = None
     media: Optional[List[WordpressMediaItem]] = None
     paid_content: Optional[str] = None
     paid_title: Optional[str] = None
@@ -412,6 +413,7 @@ def post_to_wordpress(
     title: str,
     content: str,
     slug: Optional[str] = None,
+    excerpt: Optional[str] = None,
     media: Optional[List[WordpressMediaItem]] = None,
     paid_content: Optional[str] = None,
     paid_title: Optional[str] = None,
@@ -459,6 +461,7 @@ def post_to_wordpress(
             categories=categories,
             tags=tags,
             slug=slug,
+            excerpt=excerpt,
         )
     finally:
         for p, _, _ in images:
@@ -496,6 +499,7 @@ async def wordpress_post(data: WordpressPostRequest):
         data.title,
         data.content,
         slug=data.slug,
+        excerpt=data.excerpt,
         media=data.media,
         paid_content=data.paid_content,
         paid_title=data.paid_title,

--- a/services/post_to_wordpress.py
+++ b/services/post_to_wordpress.py
@@ -87,6 +87,7 @@ def post_to_wordpress(
     categories: list[str] | None = None,
     tags: list[str] | None = None,
     slug: str | None = None,
+    excerpt: str | None = None,
 ) -> dict:
     """Create a WordPress post with optional images."""
     client = WP_CLIENT if account is None else create_wp_client(account)
@@ -148,6 +149,7 @@ def post_to_wordpress(
             categories=categories,
             tags=tags,
             slug=slug,
+            excerpt=excerpt,
         )
     except Exception as exc:
         return {"error": str(exc)}

--- a/tests/test_post_format.py
+++ b/tests/test_post_format.py
@@ -50,6 +50,7 @@ def test_endpoints_return_common_format(monkeypatch):
         categories=None,
         tags=None,
         slug=None,
+        excerpt=None,
     ):
         return {"id": 3, "link": "http://wp/3", "site": "wordpress"}
 

--- a/tests/test_wordpress_client.py
+++ b/tests/test_wordpress_client.py
@@ -106,6 +106,21 @@ def test_create_post_fallback_link(monkeypatch):
     assert res == {"id": 8, "link": "http://example/alt"}
 
 
+def test_create_post_with_excerpt(monkeypatch):
+    client = _make_client()
+
+    captured = {}
+
+    def fake_post(url, json):
+        captured["payload"] = json
+        return DummyResp({"ID": 9, "URL": "http://example/post"})
+
+    monkeypatch.setattr(client.session, "post", fake_post)
+    res = client.create_post("T", "<p>B</p>", excerpt="Short")
+    assert res == {"id": 9, "link": "http://example/post"}
+    assert captured["payload"]["excerpt"] == "Short"
+
+
 def test_get_site_info(monkeypatch):
     client = _make_client()
 

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -85,6 +85,7 @@ def test_wordpress_post_success(monkeypatch):
             "account": "acc",
             "title": "T",
             "content": "C",
+            "excerpt": "E",
             "slug": "my-slug",
             "media": [{"filename": "img.png", "data": encoded, "alt": "ALT"}],
             "paid_content": "Paid",
@@ -106,6 +107,7 @@ def test_wordpress_post_success(monkeypatch):
     assert 'alt="ALT"' in payload["content"]
     assert payload["title"] == "T"
     assert payload["slug"] == "my-slug"
+    assert payload["excerpt"] == "E"
     assert "wp:jetpack/subscribers-only-content" in payload["content"]
     assert "<h2>PT</h2>" in payload["content"]
     assert "<p>Paid</p>" in payload["content"]

--- a/tests/test_wordpress_service.py
+++ b/tests/test_wordpress_service.py
@@ -37,6 +37,7 @@ class DummyClient:
         categories=None,
         tags=None,
         slug=None,
+        excerpt=None,
     ):
         self.created = {
             "title": title,
@@ -46,6 +47,7 @@ class DummyClient:
             "categories": categories,
             "tags": tags,
             "slug": slug,
+            "excerpt": excerpt,
         }
         return {"id": 10, "link": "http://post"}
 
@@ -94,6 +96,7 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
         paid_message="Msg",
         plan_id="p1",
         slug="slug-post",
+        excerpt="Short",
     )
     assert resp["id"] == 10
     assert resp["link"] == "http://post"
@@ -115,6 +118,7 @@ def test_post_to_wordpress_uploads_and_creates(monkeypatch, tmp_path):
     # First image used as featured
     assert dummy.created["featured_id"] == 1
     assert dummy.created["slug"] == "slug-post"
+    assert dummy.created["excerpt"] == "Short"
     # Paid content added as subscribers-only block in HTML and not sent separately
     assert "wp:jetpack/subscribers-only-content" in dummy.created["html"]
     assert "<h2>PTitle</h2>" in dummy.created["html"]

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -99,6 +99,7 @@ class WordpressClient:
         categories: list[str] | None = None,
         tags: list[str] | None = None,
         slug: str | None = None,
+        excerpt: str | None = None,
     ) -> dict:
         """Create and publish a post with optional featured image."""
         url = f"{self.API_BASE.format(site=self.site)}/posts/new"
@@ -113,6 +114,8 @@ class WordpressClient:
             payload["tags"] = ",".join(tags)
         if slug:
             payload["slug"] = slug
+        if excerpt:
+            payload["excerpt"] = excerpt
         resp: requests.Response | None = None
         try:
             print(f"POST {url} payload: {payload}")


### PR DESCRIPTION
## Summary
- allow WordPress posts to include optional excerpt
- propagate excerpt through server, service, and client
- cover new excerpt field with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689da790a3648329877ef78b72437559