### PR TITLE
Add debug logging and request timeouts

### DIFF
--- a/cleanup_wordpress_posts.py
+++ b/cleanup_wordpress_posts.py
@@ -31,7 +31,9 @@ def main() -> None:
         config = {"wordpress": {"accounts": {"default": acct_cfg}}}
         client = WordpressClient(config)
         try:
+            print("Authenticating...")
             client.authenticate()
+            print("Authenticated")
         except Exception as exc:  # pragma: no cover
             print(f"Authentication failed for {name}: {exc}")
             continue
@@ -39,7 +41,9 @@ def main() -> None:
         posts: list[dict[str, Any]] = []
         page = 1
         while True:
+            print(f"Fetching posts page {page}")
             items = client.list_posts(page=page, number=100)
+            print(f"Got {len(items)} posts")
             if not items:
                 break
             posts.extend(items)
@@ -70,8 +74,10 @@ def main() -> None:
         page = 1
         removed_media = 0
         while True:
+            print(f"Fetching media page {page}")
             media = client.list_media(post_id=0, page=page, number=100)
             if not media:
+                print("Processed 0 items")
                 break
             for item in media:
                 url = item.get("URL")
@@ -82,6 +88,7 @@ def main() -> None:
                     removed_media += 1
                 except Exception as exc:  # pragma: no cover - simple CLI error handling
                     print(f"Failed to delete media {item['ID']}: {exc}")
+            print(f"Processed {len(media)} items")
             if len(media) < 100:
                 break
             page += 1

--- a/tests/test_wordpress_client.py
+++ b/tests/test_wordpress_client.py
@@ -29,7 +29,7 @@ def _make_client():
 def test_upload_media_uses_media(monkeypatch):
     client = _make_client()
 
-    def fake_post(url, files):
+    def fake_post(url, files, **kwargs):
         return DummyResp({"media": [{"id": 1, "URL": "http://example/img.jpg"}]})
 
     monkeypatch.setattr(client.session, "post", fake_post)
@@ -40,7 +40,7 @@ def test_upload_media_uses_media(monkeypatch):
 def test_upload_media_source_url(monkeypatch):
     client = _make_client()
 
-    def fake_post(url, files):
+    def fake_post(url, files, **kwargs):
         return DummyResp({"media": [{"id": 3, "source_url": "http://example/img2.jpg"}]})
 
     monkeypatch.setattr(client.session, "post", fake_post)
@@ -51,7 +51,7 @@ def test_upload_media_source_url(monkeypatch):
 def test_upload_media_fallback_link(monkeypatch):
     client = _make_client()
 
-    def fake_post(url, files):
+    def fake_post(url, files, **kwargs):
         return DummyResp({"media": [{"id": 2, "link": "http://page"}]})
 
     monkeypatch.setattr(client.session, "post", fake_post)
@@ -72,7 +72,7 @@ def test_plan_id_default_none():
 def test_get_search_terms_parses_views(monkeypatch):
     client = _make_client()
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, **kwargs):
         assert params == {"days": 7}
         return DummyResp({"search_terms": [["foo", 5], ["bar", 1]]})
 
@@ -87,7 +87,7 @@ def test_get_search_terms_parses_views(monkeypatch):
 def test_create_post_returns_link(monkeypatch):
     client = _make_client()
 
-    def fake_post(url, json):
+    def fake_post(url, json, **kwargs):
         return DummyResp({"ID": 7, "URL": "http://example/post"})
 
     monkeypatch.setattr(client.session, "post", fake_post)
@@ -98,7 +98,7 @@ def test_create_post_returns_link(monkeypatch):
 def test_create_post_fallback_link(monkeypatch):
     client = _make_client()
 
-    def fake_post(url, json):
+    def fake_post(url, json, **kwargs):
         return DummyResp({"ID": 8, "link": "http://example/alt"})
 
     monkeypatch.setattr(client.session, "post", fake_post)
@@ -111,7 +111,7 @@ def test_create_post_with_excerpt(monkeypatch):
 
     captured = {}
 
-    def fake_post(url, json):
+    def fake_post(url, json, **kwargs):
         captured["payload"] = json
         return DummyResp({"ID": 9, "URL": "http://example/post"})
 
@@ -124,7 +124,7 @@ def test_create_post_with_excerpt(monkeypatch):
 def test_get_site_info(monkeypatch):
     client = _make_client()
 
-    def fake_get(url, params=None):
+    def fake_get(url, params=None, **kwargs):
         assert params == {"fields": "icon,logo"}
         return DummyResp({"icon": {"img": "u"}})
 
@@ -136,11 +136,11 @@ def test_get_site_info(monkeypatch):
 def test_list_media_and_delete(monkeypatch):
     client = _make_client()
 
-    def fake_get(url, params=None):
+    def fake_get(url, params=None, **kwargs):
         assert params == {"page": 1, "number": 100, "post_ID": 0}
         return DummyResp({"media": [{"ID": 1}]})
 
-    def fake_post(url):
+    def fake_post(url, **kwargs):
         assert url.endswith("/media/1/delete")
         return DummyResp({})
 
@@ -154,7 +154,7 @@ def test_list_media_and_delete(monkeypatch):
 def test_update_media_alt_text(monkeypatch):
     client = _make_client()
 
-    def fake_post(url, json):
+    def fake_post(url, json, **kwargs):
         assert url.endswith("/media/5")
         assert json == {"alt_text": "New alt"}
         return DummyResp({"id": 5, "alt_text": "New alt"})
@@ -167,7 +167,7 @@ def test_update_media_alt_text(monkeypatch):
 def test_update_media_alt_text_error(monkeypatch):
     client = _make_client()
 
-    def fake_post(url, json):
+    def fake_post(url, json, **kwargs):
         raise Exception("fail")
 
     monkeypatch.setattr(client.session, "post", fake_post)

--- a/tests/test_wordpress_posts.py
+++ b/tests/test_wordpress_posts.py
@@ -29,7 +29,7 @@ def test_client_list_posts(monkeypatch):
     client = wordpress_client.WordpressClient({"wordpress": {"site": "mysite"}})
     captured = {}
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, **kwargs):
         captured["url"] = url
         captured["params"] = params
         return DummyResp(
@@ -66,7 +66,7 @@ def test_client_list_posts_status(monkeypatch):
     client = wordpress_client.WordpressClient({"wordpress": {"site": "mysite"}})
     captured = {}
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, **kwargs):
         captured["params"] = params
         return DummyResp({"posts": []})
 
@@ -78,7 +78,7 @@ def test_client_list_posts_status(monkeypatch):
 def test_wordpress_posts_endpoint(monkeypatch):
     captured = {}
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, **kwargs):
         captured["url"] = url
         captured["params"] = params
         return DummyResp(

--- a/tests/test_wordpress_posts_delete.py
+++ b/tests/test_wordpress_posts_delete.py
@@ -28,7 +28,7 @@ def test_client_delete_post(monkeypatch):
     client = wordpress_client.WordpressClient({"wordpress": {"site": "mysite"}})
     captured = {}
 
-    def fake_post(url, params=None):
+    def fake_post(url, params=None, **kwargs):
         captured["url"] = url
         captured["params"] = params
         return DummyResp({"ID": 5})
@@ -47,7 +47,7 @@ def test_client_delete_post_force(monkeypatch):
     client = wordpress_client.WordpressClient({"wordpress": {"site": "mysite"}})
     captured = {}
 
-    def fake_post(url, params=None):
+    def fake_post(url, params=None, **kwargs):
         captured["url"] = url
         captured["params"] = params
         return DummyResp({"ID": 9})

--- a/tests/test_wordpress_stats.py
+++ b/tests/test_wordpress_stats.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 def test_wordpress_views_endpoint(monkeypatch):
     captured = {}
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, **kwargs):
         captured["url"] = url
         captured["params"] = params
         class DummyResp:
@@ -49,7 +49,7 @@ def test_wordpress_views_endpoint(monkeypatch):
 def test_wordpress_views_no_data(monkeypatch):
     captured = {}
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, **kwargs):
         captured["url"] = url
         captured["params"] = params
         class DummyResp:
@@ -84,7 +84,7 @@ def test_wordpress_views_no_data(monkeypatch):
 def test_wordpress_search_terms_endpoint(monkeypatch):
     captured = {}
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, **kwargs):
         captured["url"] = url
         captured["params"] = params
         class DummyResp:

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -44,7 +44,7 @@ class WordpressClient:
         }
         resp: requests.Response | None = None
         try:
-            resp = self.session.post(self.TOKEN_URL, data=data)
+            resp = self.session.post(self.TOKEN_URL, data=data, timeout=10)
             logger.debug(
                 "Auth response status: %s, body: [redacted]", resp.status_code
             )
@@ -68,7 +68,7 @@ class WordpressClient:
         resp: requests.Response | None = None
         try:
             print(f"POST {url} with {filename}, {len(content)} bytes")
-            resp = self.session.post(url, files=files)
+            resp = self.session.post(url, files=files, timeout=10)
             print(resp.status_code, resp.text)
             print(getattr(resp, "headers", None))
             resp.raise_for_status()
@@ -119,7 +119,7 @@ class WordpressClient:
         resp: requests.Response | None = None
         try:
             print(f"POST {url} payload: {payload}")
-            resp = self.session.post(url, json=payload)
+            resp = self.session.post(url, json=payload, timeout=10)
             print(resp.status_code, resp.text)
             resp.raise_for_status()
             data = resp.json()
@@ -152,7 +152,9 @@ class WordpressClient:
             params["status"] = status
         resp: requests.Response | None = None
         try:
-            resp = self.session.get(url, headers=self.session.headers, params=params)
+            resp = self.session.get(
+                url, headers=self.session.headers, params=params, timeout=10
+            )
             resp.raise_for_status()
             data = resp.json()
             posts: list[dict] = []
@@ -186,7 +188,7 @@ class WordpressClient:
         params = {"force": 1} if permanent else None
         resp: requests.Response | None = None
         try:
-            resp = self.session.post(url, params=params)
+            resp = self.session.post(url, params=params, timeout=10)
             resp.raise_for_status()
             return post_id
         except Exception as exc:
@@ -232,7 +234,7 @@ class WordpressClient:
         params = {"fields": fields} if fields else None
         resp: requests.Response | None = None
         try:
-            resp = self.session.get(url, params=params)
+            resp = self.session.get(url, params=params, timeout=10)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:
@@ -261,7 +263,7 @@ class WordpressClient:
             params["post_ID"] = post_id
         resp: requests.Response | None = None
         try:
-            resp = self.session.get(url, params=params)
+            resp = self.session.get(url, params=params, timeout=10)
             resp.raise_for_status()
             return resp.json().get("media", [])
         except Exception as exc:
@@ -275,7 +277,7 @@ class WordpressClient:
         payload = {"alt_text": alt_text}
         resp: requests.Response | None = None
         try:
-            resp = self.session.post(url, json=payload)
+            resp = self.session.post(url, json=payload, timeout=10)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:
@@ -290,7 +292,7 @@ class WordpressClient:
         url = f"{self.API_BASE.format(site=self.site)}/media/{media_id}/delete"
         resp: requests.Response | None = None
         try:
-            resp = self.session.post(url)
+            resp = self.session.post(url, timeout=10)
             resp.raise_for_status()
             return media_id
         except Exception as exc:
@@ -304,7 +306,9 @@ class WordpressClient:
         params = {"unit": "day", "quantity": days}
         resp: requests.Response | None = None
         try:
-            resp = self.session.get(url, headers=self.session.headers, params=params)
+            resp = self.session.get(
+                url, headers=self.session.headers, params=params, timeout=10
+            )
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:
@@ -318,7 +322,9 @@ class WordpressClient:
         params = {"days": days}
         resp: requests.Response | None = None
         try:
-            resp = self.session.get(url, headers=self.session.headers, params=params)
+            resp = self.session.get(
+                url, headers=self.session.headers, params=params, timeout=10
+            )
             resp.raise_for_status()
             data = resp.json()
             terms = data.get("search_terms", [])


### PR DESCRIPTION
## Summary
- add debug prints for authentication, posts fetching, and media cleanup
- enforce 10s request timeouts in WordpressClient
- adjust tests for timeout-aware client

## Testing
- `pytest`
- `python cleanup_wordpress_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_689ff613f9748329b591c076dab962fa