### PR TITLE
feat: log media deletion progress

### DIFF
--- a/cleanup_wordpress_posts.py
+++ b/cleanup_wordpress_posts.py
@@ -79,12 +79,16 @@ def main() -> None:
             if not media:
                 print("Processed 0 items")
                 break
-            for item in media:
+            for idx, item in enumerate(media):
                 url = item.get("URL")
                 if url and url in protected:
                     continue
                 try:
+                    print(
+                        f"Deleting media {idx + 1}/{len(media)}: {item['ID']}"
+                    )
                     client.delete_media(item["ID"])
+                    print("done", flush=True)
                     removed_media += 1
                 except Exception as exc:  # pragma: no cover - simple CLI error handling
                     print(f"Failed to delete media {item['ID']}: {exc}")


### PR DESCRIPTION
## Summary
- add progress logs when deleting WordPress media

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ff8a6cd248329a22a0d54ed75dbad