### PR TITLE
feat: configure media cleanup batch size

### DIFF
--- a/cleanup_wordpress_posts.py
+++ b/cleanup_wordpress_posts.py
@@ -9,7 +9,10 @@ CONFIG_PATH = Path("config.json")
 
 def main() -> None:
     try:
+        batch_size = int(input("削除バッチサイズ: ").strip())
         max_count = int(input("最大投稿数: ").strip())
+        if batch_size <= 0:
+            raise ValueError
     except ValueError:  # pragma: no cover - simple CLI error handling
         print("Invalid number")
         return
@@ -71,11 +74,10 @@ def main() -> None:
                 if isinstance(val, str):
                     protected.add(val)
 
-        page = 1
         removed_media = 0
         while True:
-            print(f"Fetching media page {page}")
-            media = client.list_media(post_id=0, page=page, number=100)
+            print("Fetching media batch")
+            media = client.list_media(post_id=0, page=1, number=batch_size)
             if not media:
                 print("Processed 0 items")
                 break
@@ -93,9 +95,8 @@ def main() -> None:
                 except Exception as exc:  # pragma: no cover - simple CLI error handling
                     print(f"Failed to delete media {item['ID']}: {exc}")
             print(f"Processed {len(media)} items")
-            if len(media) < 100:
+            if len(media) < batch_size:
                 break
-            page += 1
 
         print(
             f"{name}: removed {deleted_posts} posts and {removed_media} unattached media items"

--- a/tests/test_cleanup_wordpress_posts.py
+++ b/tests/test_cleanup_wordpress_posts.py
@@ -41,10 +41,13 @@ def test_cleanup_wordpress_posts(tmp_path):
                 "icon": {"img": icon1},
                 "logo": {"img": logo1},
             }
-            m.list_media.return_value = [
-                {"ID": 11, "URL": icon1},
-                {"ID": 13, "URL": logo1},
-                {"ID": 12, "URL": "https://example.com/delete1.png"},
+            m.list_media.side_effect = [
+                [
+                    {"ID": 11, "URL": icon1},
+                    {"ID": 13, "URL": logo1},
+                    {"ID": 12, "URL": "https://example.com/delete1.png"},
+                ],
+                [],
             ]
         else:
             m.list_posts.return_value = [
@@ -55,16 +58,19 @@ def test_cleanup_wordpress_posts(tmp_path):
                 "icon": {"img": icon2},
                 "logo": {"img": logo2},
             }
-            m.list_media.return_value = [
-                {"ID": 21, "URL": icon2},
-                {"ID": 23, "URL": logo2},
-                {"ID": 22, "URL": "https://example.com/delete2.png"},
+            m.list_media.side_effect = [
+                [
+                    {"ID": 21, "URL": icon2},
+                    {"ID": 23, "URL": logo2},
+                    {"ID": 22, "URL": "https://example.com/delete2.png"},
+                ],
+                [],
             ]
         return m
 
     with patch("cleanup_wordpress_posts.WordpressClient", side_effect=factory), \
         patch("cleanup_wordpress_posts.CONFIG_PATH", cfg_path), \
-        patch("builtins.input", return_value="2"):
+        patch("builtins.input", side_effect=["2", "2"]):
         cwp.main()
 
     c1 = clients["site1"]
@@ -73,11 +79,13 @@ def test_cleanup_wordpress_posts(tmp_path):
     c1.list_posts.assert_called_once_with(page=1, number=100)
     c1.delete_post.assert_called_once_with(1)
     c1.empty_trash.assert_called_once()
-    c1.list_media.assert_called_once_with(post_id=0, page=1, number=100)
+    assert c1.list_media.call_count == 2
+    c1.list_media.assert_called_with(post_id=0, page=1, number=2)
     c1.delete_media.assert_called_once_with(12)
 
     c2.list_posts.assert_called_once_with(page=1, number=100)
     c2.delete_post.assert_not_called()
     c2.empty_trash.assert_not_called()
-    c2.list_media.assert_called_once_with(post_id=0, page=1, number=100)
+    assert c2.list_media.call_count == 2
+    c2.list_media.assert_called_with(post_id=0, page=1, number=2)
     c2.delete_media.assert_called_once_with(22)


### PR DESCRIPTION
## Summary
- prompt for media deletion batch size in cleanup script
- delete unattached media in user-defined batches
- adjust tests for batched media cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ff9960ca4832999509c83846ee8ab