### PR TITLE
Add retry logic for WordPress media deletions

### DIFF
--- a/cleanup_wordpress_posts.py
+++ b/cleanup_wordpress_posts.py
@@ -2,6 +2,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import requests
+
 from wordpress_client import WordpressClient
 
 CONFIG_PATH = Path("config.json")
@@ -85,15 +87,21 @@ def main() -> None:
                 url = item.get("URL")
                 if url and url in protected:
                     continue
-                try:
-                    print(
-                        f"Deleting media {idx + 1}/{len(media)}: {item['ID']}"
-                    )
-                    client.delete_media(item["ID"])
-                    print("done", flush=True)
-                    removed_media += 1
-                except Exception as exc:  # pragma: no cover - simple CLI error handling
-                    print(f"Failed to delete media {item['ID']}: {exc}")
+                print(f"Deleting media {idx + 1}/{len(media)}: {item['ID']}")
+                for attempt in range(1, 4):
+                    try:
+                        client.delete_media(item["ID"])
+                        print("done", flush=True)
+                        removed_media += 1
+                        break
+                    except requests.exceptions.RequestException as exc:
+                        if attempt < 3:
+                            print(f"Retry deleting {item['ID']}: {exc}")
+                        else:
+                            print(f"Failed to delete media {item['ID']}: {exc}")
+                    except Exception as exc:  # pragma: no cover - simple CLI error handling
+                        print(f"Failed to delete media {item['ID']}: {exc}")
+                        break
             print(f"Processed {len(media)} items")
             if len(media) < batch_size:
                 break


### PR DESCRIPTION
## Summary
- handle transient WordPress media deletion errors by retrying up to three times
- log retry attempts for easier failure analysis

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ffdfd3b3c8329b5c9c0025c7e4071