### PR TITLE
Add fields filter to WordPress media listing

### DIFF
--- a/cleanup_wordpress_posts.py
+++ b/cleanup_wordpress_posts.py
@@ -80,7 +80,9 @@ def main() -> None:
         removed_media = 0
         while True:
             print("Fetching media batch")
-            media = client.list_media(post_id=0, page=1, number=batch_size)
+            media = client.list_media(
+                post_id=0, page=1, number=batch_size, fields="ID,URL"
+            )
             if not media:
                 print("Processed 0 items")
                 break

--- a/tests/test_cleanup_wordpress_posts.py
+++ b/tests/test_cleanup_wordpress_posts.py
@@ -80,12 +80,16 @@ def test_cleanup_wordpress_posts(tmp_path):
     c1.delete_post.assert_called_once_with(1)
     c1.empty_trash.assert_called_once()
     assert c1.list_media.call_count == 2
-    c1.list_media.assert_called_with(post_id=0, page=1, number=2)
+    c1.list_media.assert_called_with(
+        post_id=0, page=1, number=2, fields="ID,URL"
+    )
     c1.delete_media.assert_called_once_with(12)
 
     c2.list_posts.assert_called_once_with(page=1, number=100)
     c2.delete_post.assert_not_called()
     c2.empty_trash.assert_not_called()
     assert c2.list_media.call_count == 2
-    c2.list_media.assert_called_with(post_id=0, page=1, number=2)
+    c2.list_media.assert_called_with(
+        post_id=0, page=1, number=2, fields="ID,URL"
+    )
     c2.delete_media.assert_called_once_with(22)

--- a/wordpress_client.py
+++ b/wordpress_client.py
@@ -243,7 +243,11 @@ class WordpressClient:
             raise RuntimeError(f"Fetching site info failed: {exc}") from exc
 
     def list_media(
-        self, post_id: int | None = None, page: int = 1, number: int = 100
+        self,
+        post_id: int | None = None,
+        page: int = 1,
+        number: int = 100,
+        fields: str | None = None,
     ) -> list[dict]:
         """Return media library items.
 
@@ -256,11 +260,16 @@ class WordpressClient:
             Page number to fetch.
         number: int
             Number of items per page (max 100).
+        fields: str | None
+            Optional comma-separated list of fields to return for each item,
+            e.g. ``"ID,URL"``.
         """
         url = f"{self.API_BASE.format(site=self.site)}/media"
         params = {"page": page, "number": number}
         if post_id is not None:
             params["post_ID"] = post_id
+        if fields is not None:
+            params["fields"] = fields
         resp: requests.Response | None = None
         try:
             resp = self.session.get(url, params=params, timeout=10)


### PR DESCRIPTION
## Summary
- add optional `fields` argument to `WordpressClient.list_media`
- request only `ID` and `URL` when listing media in cleanup script
- adjust tests for new media filtering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a000961ac48329aa983ae369e933c4