### PR TITLE
Add WordPress cleanup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,34 @@ Sample response:
 
 If an individual deletion fails, the `errors` object maps the post ID to an error message and the `failed` count is incremented.
 
+### `POST /wordpress/cleanup`
+
+Remove old posts and unattached media for one or more WordPress.com accounts.
+
+Request body:
+
+```json
+{
+  "items": [
+    { "identifier": "account1", "keep_latest": 10 },
+    { "identifier": "account2", "keep_latest": 5 }
+  ]
+}
+```
+
+For each identifier, the API keeps the specified number of most recent posts and deletes older ones. If an identifier does not match any account in `config.json`, the result contains an `error` field. After deleting posts, the trash is emptied and unattached media are removed automatically.
+
+Sample response:
+
+```json
+{
+  "results": [
+    { "account": "account1", "deleted_posts": [1, 2], "errors": {}, "trash_emptied": 2, "deleted_media": 3 },
+    { "account": "unknown", "error": "Account not found" }
+  ]
+}
+```
+
 ### `POST /note/draft`
 
 Create a draft on a configured Note account. Specify the account name in

--- a/services/cleanup_wordpress_posts.py
+++ b/services/cleanup_wordpress_posts.py
@@ -1,0 +1,90 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from services.post_to_wordpress import create_wp_client, CONFIG
+
+
+def cleanup_posts(account: str, keep_latest: int) -> Dict[str, Any]:
+    """Remove old posts and unattached media for a WordPress account.
+
+    Parameters
+    ----------
+    account: str
+        Account identifier from ``config.json``.
+    keep_latest: int
+        Number of most recent posts to retain.
+    """
+    accounts = CONFIG.get("wordpress", {}).get("accounts", {})
+    if account not in accounts:
+        return {"account": account, "error": "Account not found"}
+
+    client = create_wp_client(account)
+    if client is None:
+        return {"account": account, "error": "WordPress client unavailable"}
+
+    posts: List[Dict[str, Any]] = []
+    page = 1
+    while True:
+        items = client.list_posts(page=page, number=100)
+        if not items:
+            break
+        posts.extend(items)
+        if len(items) < 100:
+            break
+        page += 1
+
+    posts.sort(key=lambda p: p["date"])
+    delete_count = len(posts) - keep_latest
+    if delete_count <= 0:
+        return {"account": account, "deleted_posts": [], "deleted_media": 0}
+
+    deleted: List[int] = []
+    errors: Dict[str, str] = {}
+    for p in posts[:delete_count]:
+        try:
+            client.delete_post(p["id"])
+            deleted.append(p["id"])
+        except Exception as exc:
+            errors[str(p["id"])] = str(exc)
+
+    try:
+        trash = client.empty_trash()
+        trash_count = len(trash) if isinstance(trash, list) else 0
+    except Exception:
+        trash_count = 0
+
+    info = client.get_site_info(fields="icon,logo")
+    protected: set[str] = set()
+    for key in ("icon", "logo"):
+        obj = info.get(key) or {}
+        for val in obj.values():
+            if isinstance(val, str):
+                protected.add(val)
+
+    removed = 0
+    page = 1
+    while True:
+        media = client.list_media(post_id=0, page=page, number=100)
+        if not media:
+            break
+        for item in media:
+            url = item.get("URL")
+            if url and url in protected:
+                continue
+            try:
+                client.delete_media(item["ID"])
+                removed += 1
+            except Exception:
+                pass
+        if len(media) < 100:
+            break
+        page += 1
+
+    return {
+        "account": account,
+        "deleted_posts": deleted,
+        "errors": errors,
+        "trash_emptied": trash_count,
+        "deleted_media": removed,
+    }

--- a/tests/test_cleanup_wordpress_posts.py
+++ b/tests/test_cleanup_wordpress_posts.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import services.cleanup_wordpress_posts as wp_cleanup
+import services.post_to_wordpress as wp_service
+import server
+from fastapi.testclient import TestClient
+
+
+class DummyClient:
+    def __init__(self):
+        self.posts = [
+            {"id": 1, "date": "2020-01-01"},
+            {"id": 2, "date": "2020-01-02"},
+            {"id": 3, "date": "2020-01-03"},
+            {"id": 4, "date": "2020-01-04"},
+        ]
+        self.media = [{"ID": 10, "URL": "m1"}, {"ID": 11, "URL": "m2"}]
+        self.deleted_posts = []
+        self.deleted_media = []
+
+    def list_posts(self, page=1, number=100):
+        return self.posts if page == 1 else []
+
+    def delete_post(self, pid):
+        self.deleted_posts.append(pid)
+
+    def empty_trash(self):
+        return self.deleted_posts
+
+    def get_site_info(self, fields="icon,logo"):
+        return {}
+
+    def list_media(self, post_id=0, page=1, number=100):
+        return self.media if page == 1 else []
+
+    def delete_media(self, mid):
+        self.deleted_media.append(mid)
+
+
+def test_cleanup_service(monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr(wp_cleanup, "create_wp_client", lambda account: dummy)
+    cfg = {"wordpress": {"accounts": {"acc": {}}}}
+    wp_service.CONFIG = cfg
+    wp_cleanup.CONFIG = cfg
+    result = wp_cleanup.cleanup_posts("acc", 2)
+    assert result["account"] == "acc"
+    assert result["deleted_posts"] == [1, 2]
+    assert result["deleted_media"] == 2
+
+
+def test_cleanup_endpoint(monkeypatch):
+    called = []
+
+    def fake_cleanup(account, keep_latest):
+        called.append((account, keep_latest))
+        return {"account": account, "deleted_posts": []}
+
+    monkeypatch.setattr(server, "service_cleanup_posts", fake_cleanup)
+    app = TestClient(server.app)
+    resp = app.post(
+        "/wordpress/cleanup",
+        json={
+            "items": [
+                {"identifier": "a1", "keep_latest": 1},
+                {"identifier": "a2", "keep_latest": 2},
+            ]
+        },
+    )
+    assert resp.status_code == 200
+    assert called == [("a1", 1), ("a2", 2)]
+    assert resp.json() == {
+        "results": [
+            {"account": "a1", "deleted_posts": []},
+            {"account": "a2", "deleted_posts": []},
+        ]
+    }


### PR DESCRIPTION
## Summary
- expose `/wordpress/cleanup` API endpoint for bulk post and media cleanup
- implement cleanup logic and tests
- document WordPress cleanup endpoint in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a00aa4c44c83298fe93efe400983ed