### PR TITLE
Make WordPress cleanup asynchronous

### DIFF
--- a/cleanup_wordpress_api_client.py
+++ b/cleanup_wordpress_api_client.py
@@ -37,25 +37,16 @@ def main() -> None:
         for name in accounts.keys()
     ]
 
-    resp = requests.post(API_URL, json={"items": items})
-    if resp.status_code != 200:
-        print(f"Request failed ({resp.status_code}): {resp.text}")
+    try:
+        resp = requests.post(API_URL, json={"items": items}, timeout=5)
+    except Exception as exc:
+        print(f"Request failed: {exc}")
         return
 
-    data = resp.json()
-    for result in data.get("results", []):
-        account = result.get("account")
-        error = result.get("error")
-        if error:
-            print(f"{account}: {error}")
-        else:
-            deleted = len(result.get("deleted_posts", []))
-            trash = result.get("trash_emptied", 0)
-            media = result.get("deleted_media", 0)
-            print(
-                f"{account}: deleted {deleted} posts, emptied trash {trash}, "
-                f"removed {media} media items"
-            )
+    if resp.status_code == 200:
+        print("Cleanup request accepted. Check server logs for progress.")
+    else:
+        print(f"Request failed ({resp.status_code}): {resp.text}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/services/cleanup_wordpress_posts.py
+++ b/services/cleanup_wordpress_posts.py
@@ -38,6 +38,8 @@ def cleanup_posts(account: str, keep_latest: int) -> Dict[str, Any]:
     delete_count = len(posts) - keep_latest
     if delete_count <= 0:
         return {"account": account, "deleted_posts": [], "deleted_media": 0}
+    print(f"[cleanup] {account}: fetched {len(posts)} posts")
+    print(f"[cleanup] {account}: deleting {delete_count} posts")
 
     deleted: List[int] = []
     errors: Dict[str, str] = {}
@@ -47,12 +49,15 @@ def cleanup_posts(account: str, keep_latest: int) -> Dict[str, Any]:
             deleted.append(p["id"])
         except Exception as exc:
             errors[str(p["id"])] = str(exc)
+    print(f"[cleanup] {account}: deleted {len(deleted)} posts")
 
     try:
+        print(f"[cleanup] {account}: emptying trash")
         trash = client.empty_trash()
         trash_count = len(trash) if isinstance(trash, list) else 0
     except Exception:
         trash_count = 0
+    print(f"[cleanup] {account}: trash emptied {trash_count}")
 
     info = client.get_site_info(fields="icon,logo")
     protected: set[str] = set()
@@ -64,6 +69,7 @@ def cleanup_posts(account: str, keep_latest: int) -> Dict[str, Any]:
 
     removed = 0
     page = 1
+    print(f"[cleanup] {account}: removing unattached media")
     while True:
         media = client.list_media(post_id=0, page=page, number=100)
         if not media:
@@ -80,6 +86,7 @@ def cleanup_posts(account: str, keep_latest: int) -> Dict[str, Any]:
         if len(media) < 100:
             break
         page += 1
+    print(f"[cleanup] {account}: removed {removed} media items")
 
     return {
         "account": account,


### PR DESCRIPTION
## Summary
- Run WordPress cleanup requests in FastAPI background tasks and log progress per account
- Convert CLI cleanup client to fire-and-forget with short timeout
- Add default request timeout handling to `WordpressClient`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a064423d0c8329978c45b451cbb621