### PR TITLE
Add CSV export for WordPress post views

### DIFF
--- a/services/wordpress_pv_csv.py
+++ b/services/wordpress_pv_csv.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+from pathlib import Path
+
+from services.post_to_wordpress import create_wp_client
+
+
+def export_views(accounts: dict, days: int, out_dir: Path) -> list[Path]:
+    """Export daily page views for posts on multiple WordPress sites.
+
+    Parameters
+    ----------
+    accounts: dict
+        Mapping of account names to configuration dictionaries. The account
+        name is passed to ``create_wp_client`` to initialize an authenticated
+        ``WordpressClient``.
+    days: int
+        Number of days of statistics to retrieve for each post.
+    out_dir: Path
+        Directory where CSV files will be written.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    today = datetime.now().strftime("%Y%m%d")
+    generated: list[Path] = []
+
+    for account, cfg in accounts.items():
+        client = create_wp_client(account)
+        if client is None:
+            continue
+        site = cfg.get("site") or getattr(client, "site", account)
+
+        # fetch all posts across pages
+        posts: list[dict] = []
+        page = 1
+        while True:
+            try:
+                page_posts = client.list_posts(page=page, number=100)
+            except Exception:
+                break
+            if not page_posts:
+                break
+            posts.extend(page_posts)
+            page += 1
+
+        rows: list[list[str | int]] = []
+        for post in posts:
+            try:
+                view_list = client.get_daily_views(post["id"], days)
+            except Exception:
+                view_list = []
+            views = list(view_list)
+            if len(views) < days:
+                views.extend([0] * (days - len(views)))
+            row = [site, post["id"], post.get("title", "")]
+            row.extend(views[:days])
+            rows.append(row)
+
+        csv_path = out_dir / f"wp_pv_{site}_{today}.csv"
+        header = ["site", "post_id", "title"] + [f"pv_day{i+1}" for i in range(days)]
+        with csv_path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(header)
+            for row in rows:
+                writer.writerow(row)
+        generated.append(csv_path)
+
+    return generated

--- a/tests/test_wordpress_client.py
+++ b/tests/test_wordpress_client.py
@@ -173,3 +173,15 @@ def test_update_media_alt_text_error(monkeypatch):
     monkeypatch.setattr(client.session, "post", fake_post)
     with pytest.raises(RuntimeError):
         client.update_media_alt_text(5, "alt")
+
+
+def test_get_daily_views_parses_views(monkeypatch):
+    client = _make_client()
+
+    def fake_get(url, headers=None, params=None):
+        assert params == {"unit": "day", "quantity": 3}
+        return DummyResp({"days": [{"views": 4}, {"views": 2}, {"views": 1}]})
+
+    monkeypatch.setattr(client.session, "get", fake_get)
+    views = client.get_daily_views(10, 3)
+    assert views == [4, 2, 1]

--- a/tests/test_wordpress_pv_csv.py
+++ b/tests/test_wordpress_pv_csv.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from datetime import datetime
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from services.wordpress_pv_csv import export_views
+
+
+class DummyClient:
+    def __init__(self):
+        self.list_calls = []
+        self.views_calls = []
+
+    def list_posts(self, page=1, number=100):
+        self.list_calls.append(page)
+        if page == 1:
+            return [
+                {"id": 1, "title": "Post1"},
+                {"id": 2, "title": "Post2"},
+            ]
+        return []
+
+    def get_daily_views(self, post_id, days):
+        self.views_calls.append((post_id, days))
+        return list(range(1, days + 1))
+
+
+def test_export_views_writes_csv(monkeypatch, tmp_path):
+    client = DummyClient()
+    monkeypatch.setattr(
+        "services.wordpress_pv_csv.create_wp_client", lambda account: client
+    )
+    accounts = {"acc": {"site": "mysite"}}
+    paths = export_views(accounts, 7, tmp_path)
+    assert len(paths) == 1
+    csv_path = paths[0]
+    assert csv_path.exists()
+    expected_prefix = f"wp_pv_mysite_{datetime.now().strftime('%Y%m%d')}"
+    assert csv_path.name.startswith(expected_prefix)
+    with csv_path.open() as fh:
+        rows = list(csv.reader(fh))
+    header = ["site", "post_id", "title"] + [f"pv_day{i+1}" for i in range(7)]
+    assert rows[0] == header
+    assert rows[1][0:3] == ["mysite", "1", "Post1"]
+    assert rows[2][0:3] == ["mysite", "2", "Post2"]
+    assert rows[1][3:] == [str(i) for i in range(1, 8)]
+    assert rows[2][3:] == [str(i) for i in range(1, 8)]


### PR DESCRIPTION
## Summary
- add `WordpressClient.get_daily_views` for retrieving per-day view counts
- implement `export_views` to dump daily post views to per-site CSV files
- cover new behavior with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a12c90730483299f293367a46ccb51