### PR TITLE
Add WordPress page view CSV exporter

### DIFF
--- a/generate_pv_csv.py
+++ b/generate_pv_csv.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Export WordPress page views for all configured accounts.
+
+Reads ``config.json`` to obtain the list of WordPress accounts and calls
+``services.wordpress_pv_csv.export_views`` for each of them.
+"""
+
+import json
+from pathlib import Path
+
+from services.wordpress_pv_csv import export_views
+
+CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
+
+
+def main() -> None:
+    """Entry point for CSV generation."""
+    try:
+        with CONFIG_PATH.open() as f:
+            config = json.load(f)
+    except FileNotFoundError:
+        print(f"Config file not found: {CONFIG_PATH}")
+        return
+
+    accounts = config.get("wordpress", {}).get("accounts", {})
+    if not accounts:
+        print("WordPress accounts not found in config.json")
+        return
+
+    for name in accounts.keys():
+        try:
+            export_views(name)
+            print(f"Exported views for {name}")
+        except Exception as exc:  # pragma: no cover - best effort logging
+            print(f"Failed to export views for {name}: {exc}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/services/wordpress_pv_csv.py
+++ b/services/wordpress_pv_csv.py
@@ -1,0 +1,61 @@
+"""Export WordPress page view statistics to CSV."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any, Dict
+
+from services.post_to_wordpress import create_wp_client, WP_CLIENT
+
+
+def export_views(
+    account: str, days: int = 30, output_dir: str | Path = "."
+) -> Dict[str, Any]:
+    """Export view counts for all posts of the given account.
+
+    Parameters
+    ----------
+    account: str
+        Account identifier from ``config.json``.
+    days: int
+        Number of days of view statistics to retrieve per post.
+    output_dir: str | Path
+        Directory where the CSV file will be written.
+    """
+    client = WP_CLIENT if account is None else create_wp_client(account)
+    if client is None:
+        return {"account": account, "error": "WordPress client unavailable"}
+
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    csv_path = output / f"{account}_views.csv"
+
+    posts = []
+    page = 1
+    while True:
+        try:
+            items = client.list_posts(page=page, number=100)
+        except Exception as exc:
+            return {"account": account, "error": str(exc)}
+        if not items:
+            break
+        posts.extend(items)
+        if len(items) < 100:
+            break
+        page += 1
+
+    with csv_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["post_id", "title", "views"])
+        for post in posts:
+            pid = post.get("id")
+            title = post.get("title")
+            try:
+                data = client.get_post_views(pid, days)
+                views = data.get("views")
+            except Exception as exc:  # pragma: no cover - best effort
+                views = f"error: {exc}"
+            writer.writerow([pid, title, views])
+
+    return {"account": account, "csv": str(csv_path), "posts": len(posts)}


### PR DESCRIPTION
## Summary
- add command-line tool `generate_pv_csv.py` to export WordPress page views for configured accounts
- implement `services.wordpress_pv_csv.export_views` to collect view stats and write CSV files

## Testing
- `python generate_pv_csv.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a12e6b9e3083299e967391e3082f0d