### PR TITLE
Add WordPress PV CSV export endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,6 +21,7 @@ from services.wordpress_posts import (
 from services.cleanup_wordpress_posts import (
     cleanup_posts as service_cleanup_posts,
 )
+import services.wordpress_pv_csv as wordpress_pv_csv
 import os
 import tempfile
 
@@ -590,6 +591,18 @@ async def wordpress_search_terms(
     account: str | None = None,
 ):
     return service_get_search_terms(account, days)
+
+
+@app.post("/wordpress/stats/pv-csv")
+async def wordpress_pv_csv_endpoint(
+    background_tasks: BackgroundTasks,
+    days: int = Query(30, gt=0, le=30),
+    account: str | None = None,
+):
+    background_tasks.add_task(
+        wordpress_pv_csv.export_views, days=days, account=account
+    )
+    return {"status": "accepted"}
 
 
 @app.post("/note/draft")

--- a/services/wordpress_pv_csv.py
+++ b/services/wordpress_pv_csv.py
@@ -1,0 +1,64 @@
+import csv
+from pathlib import Path
+from typing import List, Dict
+
+from services.post_to_wordpress import create_wp_client, CONFIG
+
+
+def export_views(days: int = 30, account: str | None = None) -> None:
+    """Export post view counts to CSV for one or all WordPress accounts.
+
+    Parameters
+    ----------
+    days: int, default 30
+        Number of days to retrieve statistics for each post.
+    account: str | None, default None
+        Specific account identifier from ``config.json``. When ``None``
+        all configured accounts are processed.
+    """
+    accounts: Dict[str, Dict] = CONFIG.get("wordpress", {}).get("accounts", {})
+    targets: List[str]
+    if account:
+        targets = [account] if account in accounts else []
+    else:
+        targets = list(accounts.keys())
+
+    for acc in targets:
+        client = create_wp_client(acc)
+        if client is None:
+            print(f"[pv_csv] {acc}: WordPress client unavailable")
+            continue
+        posts = []
+        page = 1
+        while True:
+            items = client.list_posts(page=page, number=100)
+            if not items:
+                break
+            posts.extend(items)
+            if len(items) < 100:
+                break
+            page += 1
+        rows = []
+        for p in posts:
+            try:
+                views = client.get_post_views(p["id"], days).get("views")
+            except Exception as exc:
+                print(f"[pv_csv] {acc}: post {p['id']} views error: {exc}")
+                views = None
+            rows.append(
+                {
+                    "id": p.get("id"),
+                    "title": p.get("title"),
+                    "date": p.get("date"),
+                    "url": p.get("url"),
+                    "views": views,
+                }
+            )
+        out_file = Path(f"pv_{acc}.csv")
+        with out_file.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(
+                fh, fieldnames=["id", "title", "date", "url", "views"]
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+        print(f"[pv_csv] {acc}: exported {len(rows)} rows to {out_file}")

--- a/tests/test_wordpress_pv_csv.py
+++ b/tests/test_wordpress_pv_csv.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import server
+from fastapi.testclient import TestClient
+
+
+def test_wordpress_pv_csv_endpoint(monkeypatch):
+    called = {}
+
+    def fake_export_views(days: int = 30, account: str | None = None) -> None:
+        called["days"] = days
+        called["account"] = account
+
+    monkeypatch.setattr(server.wordpress_pv_csv, "export_views", fake_export_views)
+
+    app = TestClient(server.app)
+    resp = app.post(
+        "/wordpress/stats/pv-csv",
+        params={"days": 5, "account": "acc"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "accepted"}
+    assert called == {"days": 5, "account": "acc"}
+
+
+def test_wordpress_pv_csv_endpoint_defaults(monkeypatch):
+    called = {}
+
+    def fake_export_views(days: int = 30, account: str | None = None) -> None:
+        called["days"] = days
+        called["account"] = account
+
+    monkeypatch.setattr(server.wordpress_pv_csv, "export_views", fake_export_views)
+
+    app = TestClient(server.app)
+    resp = app.post("/wordpress/stats/pv-csv")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "accepted"}
+    assert called == {"days": 30, "account": None}


### PR DESCRIPTION
## Summary
- add background WordPress PV CSV export endpoint
- implement CSV export service for WordPress views
- add tests verifying endpoint usage with and without parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a12d77fca88329bb627e62d5fc351f