### PR TITLE
Add WordPress page view CSV exporter

### DIFF
--- a/generate_pv_csv.py
+++ b/generate_pv_csv.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Export WordPress page views for all configured accounts.
+
+Reads ``config.json`` to obtain the list of WordPress accounts and calls
+``services.wordpress_pv_csv.export_views`` for each of them.
+
+Optional ``--days`` and ``--output-dir`` arguments allow customizing the
+number of days of statistics retrieved per post and the directory where CSV
+files are written.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+from services.wordpress_pv_csv import export_views
+
+CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Export WordPress page views to CSV files",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Number of days of view statistics to fetch per post",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("."),
+        help="Directory where CSV files will be written",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point for CSV generation."""
+    args = parse_args()
+    try:
+        with CONFIG_PATH.open() as f:
+            config = json.load(f)
+    except FileNotFoundError:
+        print(f"Config file not found: {CONFIG_PATH}")
+        return
+
+    accounts = config.get("wordpress", {}).get("accounts", {})
+    if not accounts:
+        print("WordPress accounts not found in config.json")
+        return
+
+    for name in accounts.keys():
+        result = export_views(name, days=args.days, output_dir=args.output_dir)
+        if result.get("error"):
+            print(f"Failed to export views for {name}: {result['error']}")
+        else:
+            csv_path = result.get("csv")
+            posts = result.get("posts", 0)
+            print(f"Exported {posts} posts for {name} -> {csv_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/services/wordpress_pv_csv.py
+++ b/services/wordpress_pv_csv.py
@@ -1,0 +1,61 @@
+"""Export WordPress page view statistics to CSV."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any, Dict
+
+from services.post_to_wordpress import create_wp_client, WP_CLIENT
+
+
+def export_views(
+    account: str, days: int = 30, output_dir: str | Path = "."
+) -> Dict[str, Any]:
+    """Export view counts for all posts of the given account.
+
+    Parameters
+    ----------
+    account: str
+        Account identifier from ``config.json``.
+    days: int
+        Number of days of view statistics to retrieve per post.
+    output_dir: str | Path
+        Directory where the CSV file will be written.
+    """
+    client = WP_CLIENT if account is None else create_wp_client(account)
+    if client is None:
+        return {"account": account, "error": "WordPress client unavailable"}
+
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    csv_path = output / f"{account}_views.csv"
+
+    posts = []
+    page = 1
+    while True:
+        try:
+            items = client.list_posts(page=page, number=100)
+        except Exception as exc:
+            return {"account": account, "error": str(exc)}
+        if not items:
+            break
+        posts.extend(items)
+        if len(items) < 100:
+            break
+        page += 1
+
+    with csv_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["post_id", "title", "views"])
+        for post in posts:
+            pid = post.get("id")
+            title = post.get("title")
+            try:
+                data = client.get_post_views(pid, days)
+                views = data.get("views")
+            except Exception as exc:  # pragma: no cover - best effort
+                views = f"error: {exc}"
+            writer.writerow([pid, title, views])
+
+    return {"account": account, "csv": str(csv_path), "posts": len(posts)}

--- a/tests/test_wordpress_pv_csv.py
+++ b/tests/test_wordpress_pv_csv.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import services.wordpress_pv_csv as wp_pv
+
+
+def test_export_views_writes_csv(monkeypatch, tmp_path):
+    posts = [
+        {"id": 1, "title": "one"},
+        {"id": 2, "title": "two"},
+    ]
+
+    class DummyClient:
+        def list_posts(self, page=1, number=100):
+            return posts if page == 1 else []
+
+        def get_post_views(self, post_id, days):  # noqa: D401
+            return {"views": post_id * 10}
+
+    client = DummyClient()
+    monkeypatch.setattr(wp_pv, "WP_CLIENT", client)
+    monkeypatch.setattr(wp_pv, "create_wp_client", lambda account: client)
+
+    result = wp_pv.export_views("acc", days=7, output_dir=tmp_path)
+    csv_file = tmp_path / "acc_views.csv"
+    assert result == {
+        "account": "acc",
+        "csv": str(csv_file),
+        "posts": 2,
+    }
+    content = csv_file.read_text().splitlines()
+    assert content == [
+        "post_id,title,views",
+        "1,one,10",
+        "2,two,20",
+    ]
+
+
+def test_export_views_client_error(monkeypatch):
+    monkeypatch.setattr(wp_pv, "create_wp_client", lambda account: None)
+    result = wp_pv.export_views("missing")
+    assert result["error"] == "WordPress client unavailable"


### PR DESCRIPTION
## Summary
- add command-line tool `generate_pv_csv.py` to export WordPress page views for configured accounts
- expose CLI options to choose days and output directory for CSV exports
- add tests covering CSV export of views

## Testing
- `python generate_pv_csv.py --days 5 --output-dir example`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a12e6b9e3083299e967391e3082f0d