### PR TITLE
Add WordPress daily views method

### DIFF
--- a/tests/test_wordpress_client.py
+++ b/tests/test_wordpress_client.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-
+import wordpress_client
 from wordpress_client import WordpressClient
 
 
@@ -173,3 +173,29 @@ def test_update_media_alt_text_error(monkeypatch):
     monkeypatch.setattr(client.session, "post", fake_post)
     with pytest.raises(RuntimeError):
         client.update_media_alt_text(5, "alt")
+
+
+def test_get_daily_views_batches(monkeypatch):
+    client = _make_client()
+    captured: list[dict] = []
+
+    def fake_get(url, headers=None, params=None):
+        captured.append(params)
+        ids = params["post_ids"].split(",")
+        if len(ids) == 100:
+            return DummyResp({"views": {pid: 1 for pid in ids}})
+        return DummyResp({"views": {ids[0]: 2}})
+
+    monkeypatch.setattr(client.session, "get", fake_get)
+    sleeps: list[float] = []
+    monkeypatch.setattr(wordpress_client.time, "sleep", lambda s: sleeps.append(s))
+    res = client.get_daily_views(list(range(1, 102)), "2024-01-01")
+    assert res[1] == 1
+    assert res[100] == 1
+    assert res[101] == 2
+    assert len(captured) == 2
+    assert len(sleeps) == 2
+    assert captured[0]["day"] == "2024-01-01"
+    assert captured[1]["day"] == "2024-01-01"
+    assert len(captured[0]["post_ids"].split(",")) == 100
+    assert captured[1]["post_ids"] == "101"


### PR DESCRIPTION
## Summary
- extend `WordpressClient` with `get_daily_views` to batch post IDs and fetch per-day views
- test batching and throttling logic for daily views requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a13ab75f0083298e7e08dc3aa3e4ae