### PR TITLE
Add endpoint for WordPress PV CSV export

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,6 +21,9 @@ from services.wordpress_posts import (
 from services.cleanup_wordpress_posts import (
     cleanup_posts as service_cleanup_posts,
 )
+from services.wordpress_pv_csv import (
+    export_views as service_export_views,
+)
 import os
 import tempfile
 
@@ -590,6 +593,20 @@ async def wordpress_search_terms(
     account: str | None = None,
 ):
     return service_get_search_terms(account, days)
+
+
+@app.post("/wordpress/stats/pv-csv")
+async def wordpress_pv_csv(
+    background_tasks: BackgroundTasks,
+    days: int = Query(30, gt=0, le=30),
+    out_dir: str | None = Query(None),
+):
+    accounts = CONFIG.get("wordpress", {}).get("accounts", {})
+    output_path = Path(out_dir) if out_dir else Path(tempfile.gettempdir())
+    background_tasks.add_task(
+        service_export_views, accounts, days, output_path
+    )
+    return {"status": "accepted"}
 
 
 @app.post("/note/draft")

--- a/tests/test_wordpress_pv_csv.py
+++ b/tests/test_wordpress_pv_csv.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import server
+
+
+def test_wordpress_pv_csv_endpoint(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_export(accounts, days, out_dir):
+        captured["accounts"] = accounts
+        captured["days"] = days
+        captured["out_dir"] = out_dir
+
+    monkeypatch.setattr(server, "service_export_views", fake_export)
+    cfg = {"wordpress": {"accounts": {"acc1": {}, "acc2": {}}}}
+    monkeypatch.setattr(server, "CONFIG", cfg, raising=False)
+
+    client = TestClient(server.app)
+    resp = client.post(
+        "/wordpress/stats/pv-csv",
+        params={"days": 5, "out_dir": str(tmp_path)},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "accepted"}
+    assert captured["accounts"] == cfg["wordpress"]["accounts"]
+    assert captured["days"] == 5
+    assert captured["out_dir"] == tmp_path


### PR DESCRIPTION
## Summary
- expose `/wordpress/stats/pv-csv` endpoint that triggers background CSV export for all WordPress accounts
- cover new endpoint with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a13e19079c8329b4d08615374e322c