### PR TITLE
docs: document pv CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,35 @@ Sample response:
 }
 ```
 
+### `POST /wordpress/stats/pv-csv`
+
+Export per-post view counts for all configured WordPress.com accounts as CSV files.
+
+Query parameters:
+
+- `days`: Number of recent days to include (default `30`).
+- `out_dir`: Directory to write the CSV files to. Use `csv` to save them under the built-in `csv/` folder.
+
+The generated CSV has columns in the order
+`site, post_id, page_name, pv_day1 … pv_day7` when `days` is set to `7`.
+
+Example using `curl`:
+
+```bash
+curl -X POST "http://localhost:8765/wordpress/stats/pv-csv?days=7&out_dir=csv"
+```
+
+### Standalone CSV generation
+
+You can generate the same statistics without running the server:
+
+```bash
+python generate_pv_csv.py --days 7 --out-dir csv
+```
+
+Each WordPress account produces a file named `<account>_views.csv` in the specified
+directory.
+
 ### `GET /wordpress/posts`
 
 List recent posts on a WordPress.com site.


### PR DESCRIPTION
## Summary
- document `/wordpress/stats/pv-csv` endpoint with example request and column order
- note how to run `generate_pv_csv.py` standalone and where CSV files are saved

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1421cfd0c8329919f5a38a93c103a